### PR TITLE
[codex] Add macOS trojan-client support

### DIFF
--- a/.github/workflows/trojan-client-macos.yml
+++ b/.github/workflows/trojan-client-macos.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build trojan-client macOS app
         working-directory: trojan-client
-        run: npm run build
+        run: npm run build:macos
 
       - name: Upload macOS bundles
         uses: actions/upload-artifact@v4

--- a/.github/workflows/trojan-client-macos.yml
+++ b/.github/workflows/trojan-client-macos.yml
@@ -1,0 +1,50 @@
+name: Trojan Client macOS
+
+on:
+  push:
+    branches:
+      - master
+      - feature/macos-trojan-client
+  pull_request:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: trojan-client/package-lock.json
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install frontend dependencies
+        working-directory: trojan-client
+        run: npm ci
+
+      - name: Build trojan sidecar
+        run: cargo build --release
+
+      - name: Build trojan-client macOS app
+        working-directory: trojan-client
+        run: npm run build
+
+      - name: Upload macOS bundles
+        uses: actions/upload-artifact@v4
+        with:
+          name: trojan-client-macos
+          path: |
+            trojan-client/src-tauri/target/release/bundle/macos/*.app
+            trojan-client/src-tauri/target/release/bundle/dmg/*.dmg
+          if-no-files-found: error

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ winapi = { version = "0.3", features = ["netioapi", "impl-debug", "impl-default"
 
 [target.'cfg(not(windows))'.dependencies]
 backtrace-on-stack-overflow = "0.3"
+
+[target.'cfg(target_os = "linux")'.dependencies]
 ipset = { version = "0.9" }
 
 [dependencies.fern]

--- a/src/aproxy/mod.rs
+++ b/src/aproxy/mod.rs
@@ -140,10 +140,10 @@ async fn async_run() -> Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(not(target_os = "linux"))]
 async fn wait_until_stop(_running: Arc<AtomicBool>, _ip: IpAddr) {}
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
 async fn wait_until_stop(running: Arc<AtomicBool>, ip: IpAddr) {
     let timeout = OPTIONS.proxy_args().ipset_timeout;
     {

--- a/src/aproxy/profiler.rs
+++ b/src/aproxy/profiler.rs
@@ -97,7 +97,7 @@ async fn start_check_routine(
 async fn start_response(mut receiver: UnboundedReceiver<(IpAddr, bool)>, name: String) {
     log::info!("start response routine");
     cfg_if::cfg_if! {
-        if #[cfg(unix)] {
+        if #[cfg(target_os = "linux")] {
             let mut session:ipset::Session<ipset::types::HashIp> = ipset::Session::new(name);
             if let Err(err) = session.flush() {
                 log::error!("flush ipset failed:{:?}", err);
@@ -112,7 +112,7 @@ async fn start_response(mut receiver: UnboundedReceiver<(IpAddr, bool)>, name: S
         };
         log::warn!("{} should be bypassed", ip);
         cfg_if::cfg_if! {
-            if #[cfg(unix)] {
+            if #[cfg(target_os = "linux")] {
                 if let Err(err) = if add {
                     session.add(ip, &[])
                 } else {
@@ -136,7 +136,7 @@ async fn start_request(
     let config = ConfigBuilder::default().kind(ICMP::V4).build();
     let client = Arc::new(Client::new(&config).unwrap());
     cfg_if::cfg_if! {
-        if #[cfg(unix)] {
+        if #[cfg(target_os = "linux")] {
             let mut session:ipset::Session<ipset::types::HashIp> = ipset::Session::new(name);
         }
     }
@@ -148,7 +148,7 @@ async fn start_request(
             break;
         };
         cfg_if::cfg_if! {
-            if #[cfg(unix)] {
+            if #[cfg(target_os = "linux")] {
                 if let Ok(true) = session.test(ip) {
                     if let Err(err) = sender.send((ip, u16::MAX, u8::MAX)) {
                         log::error!("send local ping for {} failed:{}", ip, err);

--- a/src/awintun/mod.rs
+++ b/src/awintun/mod.rs
@@ -1,36 +1,50 @@
 use std::{
     fs::OpenOptions,
     io::Write,
-    net::{Ipv4Addr, SocketAddr},
+    net::SocketAddr,
     sync::Arc,
     time::{Duration, Instant},
 };
 
+use async_smoltcp::{Tun, TunDevice};
 use bytes::BytesMut;
 use rustls::{ClientConfig, RootCertStore};
 use rustls_pki_types::ServerName;
 use tokio::{net::TcpStream, runtime::Runtime, spawn, sync::mpsc::channel};
 use tokio_rustls::{client::TlsStream, TlsConnector};
-use wintun::Adapter;
-
-use async_smoltcp::TunDevice;
 use types::Result;
+
+#[cfg(windows)]
+use std::net::Ipv4Addr;
+#[cfg(windows)]
 use wintool::adapter::get_main_adapter_gwif;
+#[cfg(windows)]
+use wintun::Adapter;
 
 use crate::{
     awintun::{
         tcp::start_tcp,
-        tun::Wintun,
         udp::{run_udp_dispatch, start_udp},
     },
     config::OPTIONS,
     proto::{TrojanRequest, UDP_ASSOCIATE},
     types,
+};
+
+#[cfg(target_os = "macos")]
+use crate::osxtun::{
+    route::{build_cleanup_commands, default_gateway, run_commands, RouteConfig, RouteGuard},
+    tun::OsxTun,
+};
+#[cfg(windows)]
+use crate::{
+    awintun::tun::Wintun,
     types::TrojanError,
     wintun::{apply_ipset, route_add_with_if},
 };
 
 mod tcp;
+#[cfg(windows)]
 mod tun;
 mod udp;
 
@@ -52,6 +66,7 @@ pub fn run() -> Result<()> {
     runtime.block_on(async_run())
 }
 
+#[cfg(windows)]
 async fn async_run() -> Result<()> {
     log::info!("dll:{}", OPTIONS.wintun_args().wintun);
     let wintun = unsafe { wintun::load_from_path(&OPTIONS.wintun_args().wintun)? };
@@ -78,6 +93,52 @@ async fn async_run() -> Result<()> {
         apply_ipset(file, index, main_gw, main_index)?;
     }
 
+    let server_addr = *OPTIONS.back_addr.as_ref().unwrap();
+    let mtu = OPTIONS.wintun_args().mtu;
+    let mut device = TunDevice::new(Wintun::new(mtu, session));
+    device.add_black_ip(server_addr.ip());
+    run_device(device).await
+}
+
+#[cfg(target_os = "macos")]
+async fn async_run() -> Result<()> {
+    let server_addr = *OPTIONS.back_addr.as_ref().unwrap();
+    let server_ip = match server_addr.ip() {
+        std::net::IpAddr::V4(ip) => ip,
+        std::net::IpAddr::V6(_) => {
+            return Err(types::TrojanError::Custom(
+                "osxtun only supports IPv4 server route now".to_string(),
+            ))
+        }
+    };
+    let mtu = OPTIONS.wintun_args().mtu;
+    let tun = OsxTun::create(mtu)?;
+    let interface = tun.interface_name().to_string();
+    let route_config = RouteConfig {
+        interface: interface.clone(),
+        gateway: default_gateway()?,
+        server_ip,
+        tun_addr: "10.255.0.2".parse()?,
+        tun_peer: "10.255.0.1".parse()?,
+        mtu,
+    };
+    let _ = run_commands(&build_cleanup_commands(&route_config));
+    let _route_guard = RouteGuard::apply(route_config)?;
+    log::warn!(
+        "osxtun started on {} with server:{}",
+        interface,
+        server_addr
+    );
+    let mut device = TunDevice::new(tun);
+    device.add_black_ip(server_addr.ip());
+    device.allow_private(true);
+    run_device(device).await
+}
+
+async fn run_device<T>(mut device: TunDevice<'_, T>) -> Result<()>
+where
+    T: Tun + Clone,
+{
     let server_name: ServerName = OPTIONS.wintun_args().hostname.as_str().try_into()?;
 
     let mut root_store = RootCertStore::empty();
@@ -88,11 +149,6 @@ async fn async_run() -> Result<()> {
             .with_root_certificates(root_store)
             .with_no_client_auth(),
     );
-
-    let server_addr = *OPTIONS.back_addr.as_ref().unwrap();
-    let mtu = OPTIONS.wintun_args().mtu;
-    let mut device = TunDevice::new(Wintun::new(mtu, session));
-    device.add_black_ip(server_addr.ip());
 
     let empty: SocketAddr = "0.0.0.0:0".parse().unwrap();
     let mut header = BytesMut::new();
@@ -108,7 +164,7 @@ async fn async_run() -> Result<()> {
         socket_receiver,
         server_name.clone(),
         connector.clone(),
-        mtu,
+        OPTIONS.wintun_args().mtu,
         udp_header.clone(),
         close_receiver,
         close_sender.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,8 @@ pub enum Mode {
         about = "run in asynchronous windows tun mode"
     )]
     Awintun(WintunArgs),
+    #[clap(version, name = "osxtun", about = "run in macOS utun mode")]
+    Osxtun(WintunArgs),
     #[clap(version, name = "dns", about = "run in dns mode")]
     Dns(DnsArgs),
 }
@@ -337,8 +339,8 @@ impl Opts {
     #[allow(dead_code)]
     pub fn wintun_args(&self) -> &WintunArgs {
         match self.mode {
-            Mode::Wintun(ref args) | Mode::Awintun(ref args) => args,
-            _ => panic!("not in wintun mode"),
+            Mode::Wintun(ref args) | Mode::Awintun(ref args) | Mode::Osxtun(ref args) => args,
+            _ => panic!("not in tun mode"),
         }
     }
 
@@ -416,7 +418,7 @@ impl Opts {
                 let port = args.port;
                 self.resolve(hostname, port, None);
             }
-            Mode::Wintun(ref args) | Mode::Awintun(ref args) => {
+            Mode::Wintun(ref args) | Mode::Awintun(ref args) | Mode::Osxtun(ref args) => {
                 let hostname = args.hostname.clone();
                 let port = args.port;
                 let dns_server = args.dns_server_addr.clone();
@@ -520,4 +522,36 @@ lazy_static::lazy_static! {
         opts.setup();
         opts
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::{Mode, Opts};
+
+    #[test]
+    fn parses_osxtun_mode_with_wintun_args() {
+        let opts = Opts::try_parse_from([
+            "trojan",
+            "-a",
+            "127.0.0.1:60080",
+            "-p",
+            "password",
+            "osxtun",
+            "-n",
+            "utun",
+            "-H",
+            "example.com",
+        ])
+        .unwrap();
+
+        match opts.mode {
+            Mode::Osxtun(args) => {
+                assert_eq!(args.name, "utun");
+                assert_eq!(args.hostname, "example.com");
+            }
+            _ => panic!("expected osxtun mode"),
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,12 +15,17 @@ cfg_if::cfg_if! {
         mod dns;
         mod wintun;
         mod awintun;
+    } else if #[cfg(target_os = "macos")] {
+        mod awintun;
+        mod osxtun;
     }
 }
 mod aproxy;
 mod aserver;
 mod async_utils;
 mod idle_pool;
+#[cfg(all(test, not(target_os = "macos")))]
+mod osxtun;
 mod proto;
 mod proxy;
 mod resolver;
@@ -82,17 +87,27 @@ fn main() {
                     log::warn!("trojan started in wintun mode with server:{}", OPTIONS.back_addr.as_ref().unwrap());
                     wintun::run()
                 } else {
-                    panic!("trojan in wintun mode not supported on non-windows platform");
+                    panic!("trojan in wintun mode only supported on Windows");
                 }
             }
         }
         Mode::Awintun(_) => {
             cfg_if::cfg_if! {
                 if #[cfg(windows)] {
-                    log::warn!("trojan started in wintun mode with server:{}", OPTIONS.back_addr.as_ref().unwrap());
+                    log::warn!("trojan started in awintun mode with server:{}", OPTIONS.back_addr.as_ref().unwrap());
                     awintun::run()
                 } else {
-                    panic!("trojan in wintun mode not supported on non-windows platform");
+                    panic!("trojan in awintun mode only supported on Windows");
+                }
+            }
+        }
+        Mode::Osxtun(_) => {
+            cfg_if::cfg_if! {
+                if #[cfg(target_os = "macos")] {
+                    log::warn!("trojan started in osxtun mode with server:{}", OPTIONS.back_addr.as_ref().unwrap());
+                    awintun::run()
+                } else {
+                    panic!("trojan in osxtun mode only supported on macOS");
                 }
             }
         }
@@ -104,7 +119,7 @@ fn main() {
                     dns::set_dns_server("".into());
                     ret
                 } else {
-                    panic!("trojan in dns mode not supported on non-windows platform");
+                    panic!("trojan in dns mode only supported on Windows");
                 }
             }
         }

--- a/src/osxtun/mod.rs
+++ b/src/osxtun/mod.rs
@@ -1,0 +1,4 @@
+pub mod route;
+
+#[cfg(target_os = "macos")]
+pub mod tun;

--- a/src/osxtun/route.rs
+++ b/src/osxtun/route.rs
@@ -1,0 +1,252 @@
+#[cfg(target_os = "macos")]
+use crate::types::Result;
+use std::net::Ipv4Addr;
+#[cfg(target_os = "macos")]
+use std::process::Command;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RouteConfig {
+    pub interface: String,
+    pub gateway: Ipv4Addr,
+    pub server_ip: Ipv4Addr,
+    pub tun_addr: Ipv4Addr,
+    pub tun_peer: Ipv4Addr,
+    pub mtu: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommandSpec {
+    pub program: String,
+    pub args: Vec<String>,
+    pub ignore_failure: bool,
+}
+
+impl CommandSpec {
+    fn new(program: &str, args: Vec<String>) -> Self {
+        Self {
+            program: program.to_string(),
+            args,
+            ignore_failure: false,
+        }
+    }
+
+    fn ignore_failure(mut self) -> Self {
+        self.ignore_failure = true;
+        self
+    }
+}
+
+pub fn build_apply_commands(config: &RouteConfig) -> Vec<CommandSpec> {
+    vec![
+        CommandSpec::new(
+            "ifconfig",
+            vec![
+                config.interface.clone(),
+                "inet".to_string(),
+                config.tun_addr.to_string(),
+                config.tun_peer.to_string(),
+                "mtu".to_string(),
+                config.mtu.to_string(),
+                "up".to_string(),
+            ],
+        ),
+        CommandSpec::new(
+            "route",
+            vec![
+                "-n".to_string(),
+                "add".to_string(),
+                "-host".to_string(),
+                config.server_ip.to_string(),
+                config.gateway.to_string(),
+            ],
+        ),
+        delete_split_route("0.0.0.0/1", &config.interface).ignore_failure(),
+        delete_split_route("128.0.0.0/1", &config.interface).ignore_failure(),
+        add_split_route("0.0.0.0/1", &config.interface),
+        add_split_route("128.0.0.0/1", &config.interface),
+    ]
+}
+
+pub fn build_cleanup_commands(config: &RouteConfig) -> Vec<CommandSpec> {
+    vec![
+        delete_split_route("0.0.0.0/1", &config.interface).ignore_failure(),
+        delete_split_route("128.0.0.0/1", &config.interface).ignore_failure(),
+        CommandSpec::new(
+            "route",
+            vec![
+                "-n".to_string(),
+                "delete".to_string(),
+                "-host".to_string(),
+                config.server_ip.to_string(),
+                config.gateway.to_string(),
+            ],
+        )
+        .ignore_failure(),
+    ]
+}
+
+fn add_split_route(cidr: &str, interface: &str) -> CommandSpec {
+    CommandSpec::new(
+        "route",
+        vec![
+            "-n".to_string(),
+            "add".to_string(),
+            "-net".to_string(),
+            cidr.to_string(),
+            "-interface".to_string(),
+            interface.to_string(),
+        ],
+    )
+}
+
+fn delete_split_route(cidr: &str, interface: &str) -> CommandSpec {
+    CommandSpec::new(
+        "route",
+        vec![
+            "-n".to_string(),
+            "delete".to_string(),
+            "-net".to_string(),
+            cidr.to_string(),
+            "-interface".to_string(),
+            interface.to_string(),
+        ],
+    )
+}
+
+pub fn parse_default_gateway(output: &str) -> Option<Ipv4Addr> {
+    output.lines().find_map(|line| {
+        let line = line.trim();
+        let gateway = line.strip_prefix("gateway:")?.trim();
+        gateway.parse().ok()
+    })
+}
+
+#[cfg(target_os = "macos")]
+pub fn default_gateway() -> Result<Ipv4Addr> {
+    let output = Command::new("route")
+        .args(["-n", "get", "default"])
+        .output()?;
+    if !output.status.success() {
+        return Err(crate::types::TrojanError::Custom(format!(
+            "route -n get default failed:{}",
+            output.status
+        )));
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    parse_default_gateway(&text)
+        .ok_or_else(|| crate::types::TrojanError::Custom("default gateway not found".to_string()))
+}
+
+#[cfg(target_os = "macos")]
+pub fn run_commands(commands: &[CommandSpec]) -> Result<()> {
+    for command in commands {
+        log::info!("run command: {} {:?}", command.program, command.args);
+        let status = Command::new(&command.program)
+            .args(&command.args)
+            .status()?;
+        if !status.success() && !command.ignore_failure {
+            return Err(crate::types::TrojanError::Custom(format!(
+                "command failed: {} {:?}, status:{}",
+                command.program, command.args, status
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub struct RouteGuard {
+    config: RouteConfig,
+}
+
+#[cfg(target_os = "macos")]
+impl RouteGuard {
+    pub fn apply(config: RouteConfig) -> Result<Self> {
+        run_commands(&build_apply_commands(&config))?;
+        Ok(Self { config })
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for RouteGuard {
+    fn drop(&mut self) {
+        if let Err(err) = run_commands(&build_cleanup_commands(&self.config)) {
+            log::error!("cleanup osxtun route failed:{:?}", err);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::{build_apply_commands, build_cleanup_commands, parse_default_gateway, RouteConfig};
+
+    #[test]
+    fn apply_commands_add_server_route_before_split_default_routes() {
+        let config = RouteConfig {
+            interface: "utun7".to_string(),
+            gateway: Ipv4Addr::new(192, 168, 31, 1),
+            server_ip: Ipv4Addr::new(8, 8, 8, 8),
+            tun_addr: Ipv4Addr::new(10, 255, 0, 2),
+            tun_peer: Ipv4Addr::new(10, 255, 0, 1),
+            mtu: 1400,
+        };
+
+        let commands = build_apply_commands(&config);
+        let args: Vec<Vec<String>> = commands.into_iter().map(|cmd| cmd.args).collect();
+
+        assert_eq!(
+            args,
+            vec![
+                vec![
+                    "utun7",
+                    "inet",
+                    "10.255.0.2",
+                    "10.255.0.1",
+                    "mtu",
+                    "1400",
+                    "up"
+                ],
+                vec!["-n", "add", "-host", "8.8.8.8", "192.168.31.1"],
+                vec!["-n", "delete", "-net", "0.0.0.0/1", "-interface", "utun7"],
+                vec!["-n", "delete", "-net", "128.0.0.0/1", "-interface", "utun7"],
+                vec!["-n", "add", "-net", "0.0.0.0/1", "-interface", "utun7"],
+                vec!["-n", "add", "-net", "128.0.0.0/1", "-interface", "utun7"],
+            ]
+        );
+    }
+
+    #[test]
+    fn cleanup_commands_remove_split_defaults_and_server_route() {
+        let config = RouteConfig {
+            interface: "utun7".to_string(),
+            gateway: Ipv4Addr::new(192, 168, 31, 1),
+            server_ip: Ipv4Addr::new(8, 8, 8, 8),
+            tun_addr: Ipv4Addr::new(10, 255, 0, 2),
+            tun_peer: Ipv4Addr::new(10, 255, 0, 1),
+            mtu: 1400,
+        };
+
+        let commands = build_cleanup_commands(&config);
+        let args: Vec<Vec<String>> = commands.into_iter().map(|cmd| cmd.args).collect();
+
+        assert_eq!(
+            args,
+            vec![
+                vec!["-n", "delete", "-net", "0.0.0.0/1", "-interface", "utun7"],
+                vec!["-n", "delete", "-net", "128.0.0.0/1", "-interface", "utun7"],
+                vec!["-n", "delete", "-host", "8.8.8.8", "192.168.31.1"],
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_default_gateway_from_route_output() {
+        let output = "   route to: default\ndestination: default\n       mask: default\n    gateway: 192.168.31.1\n  interface: en0\n";
+        assert_eq!(
+            parse_default_gateway(output),
+            Some(Ipv4Addr::new(192, 168, 31, 1))
+        );
+    }
+}

--- a/src/osxtun/tun.rs
+++ b/src/osxtun/tun.rs
@@ -11,6 +11,7 @@ use async_smoltcp::{Packet, Tun};
 const UTUN_CONTROL_NAME: &[u8] = b"com.apple.net.utun_control\0";
 const UTUN_OPT_IFNAME: libc::c_int = 2;
 const UTUN_HEADER_SIZE: usize = 4;
+const UTUN_RECEIVE_BUFFER_SIZE: usize = 16 * 1024;
 
 #[derive(Clone)]
 pub struct OsxTun {
@@ -50,8 +51,9 @@ impl Tun for OsxTun {
     type Packet = TunPacket;
 
     fn receive(&self) -> Result<Option<Self::Packet>> {
-        let mut buf = vec![0u8; self.mtu + UTUN_HEADER_SIZE];
-        let read = unsafe { libc::read(self.fd.0, buf.as_mut_ptr().cast(), buf.len()) };
+        let mut buf = [0u8; UTUN_RECEIVE_BUFFER_SIZE];
+        let len = (self.mtu + UTUN_HEADER_SIZE).min(buf.len());
+        let read = unsafe { libc::read(self.fd.0, buf.as_mut_ptr().cast(), len) };
         if read < 0 {
             let err = Error::last_os_error();
             return if err.kind() == ErrorKind::WouldBlock {
@@ -64,9 +66,10 @@ impl Tun for OsxTun {
         if read <= UTUN_HEADER_SIZE {
             return Ok(None);
         }
-        buf.drain(..UTUN_HEADER_SIZE);
-        buf.truncate(read - UTUN_HEADER_SIZE);
-        Ok(Some(TunPacket(buf)))
+        let packet_len = read - UTUN_HEADER_SIZE;
+        let mut packet_buf = vec![0u8; packet_len];
+        packet_buf.copy_from_slice(&buf[UTUN_HEADER_SIZE..read]);
+        Ok(Some(TunPacket(packet_buf)))
     }
 
     fn send(&self, packet: Self::Packet) -> Result<()> {
@@ -80,12 +83,24 @@ impl Tun for OsxTun {
                 ))
             }
         };
-        let mut buf = Vec::with_capacity(packet.0.len() + UTUN_HEADER_SIZE);
-        buf.extend_from_slice(&family.to_be_bytes());
-        buf.extend_from_slice(&packet.0);
-        let written = unsafe { libc::write(self.fd.0, buf.as_ptr().cast(), buf.len()) };
+        let family_bytes = family.to_be_bytes();
+        let iov = [
+            libc::iovec {
+                iov_base: family_bytes.as_ptr() as *mut _,
+                iov_len: family_bytes.len(),
+            },
+            libc::iovec {
+                iov_base: packet.0.as_ptr() as *mut _,
+                iov_len: packet.0.len(),
+            },
+        ];
+        let written = unsafe { libc::writev(self.fd.0, iov.as_ptr(), iov.len() as i32) };
         if written < 0 {
             return Err(Error::last_os_error());
+        }
+        let expected = family_bytes.len() + packet.0.len();
+        if written as usize != expected {
+            return Err(Error::new(ErrorKind::WriteZero, "short utun packet write"));
         }
         Ok(())
     }

--- a/src/osxtun/tun.rs
+++ b/src/osxtun/tun.rs
@@ -1,0 +1,187 @@
+use std::{
+    ffi::CStr,
+    io::{Error, ErrorKind, Result},
+    mem,
+    os::fd::RawFd,
+    sync::Arc,
+};
+
+use async_smoltcp::{Packet, Tun};
+
+const UTUN_CONTROL_NAME: &[u8] = b"com.apple.net.utun_control\0";
+const UTUN_OPT_IFNAME: libc::c_int = 2;
+const UTUN_HEADER_SIZE: usize = 4;
+
+#[derive(Clone)]
+pub struct OsxTun {
+    fd: Arc<Fd>,
+    mtu: usize,
+    interface_name: String,
+}
+
+struct Fd(RawFd);
+
+impl Drop for Fd {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.0);
+        }
+    }
+}
+
+impl OsxTun {
+    pub fn create(mtu: usize) -> Result<Self> {
+        let fd = create_utun_fd()?;
+        set_nonblocking(fd)?;
+        let interface_name = interface_name(fd)?;
+        Ok(Self {
+            fd: Arc::new(Fd(fd)),
+            mtu,
+            interface_name,
+        })
+    }
+
+    pub fn interface_name(&self) -> &str {
+        &self.interface_name
+    }
+}
+
+impl Tun for OsxTun {
+    type Packet = TunPacket;
+
+    fn receive(&self) -> Result<Option<Self::Packet>> {
+        let mut buf = vec![0u8; self.mtu + UTUN_HEADER_SIZE];
+        let read = unsafe { libc::read(self.fd.0, buf.as_mut_ptr().cast(), buf.len()) };
+        if read < 0 {
+            let err = Error::last_os_error();
+            return if err.kind() == ErrorKind::WouldBlock {
+                Ok(None)
+            } else {
+                Err(err)
+            };
+        }
+        let read = read as usize;
+        if read <= UTUN_HEADER_SIZE {
+            return Ok(None);
+        }
+        buf.drain(..UTUN_HEADER_SIZE);
+        buf.truncate(read - UTUN_HEADER_SIZE);
+        Ok(Some(TunPacket(buf)))
+    }
+
+    fn send(&self, packet: Self::Packet) -> Result<()> {
+        let family = match packet.0.first().map(|byte| byte >> 4) {
+            Some(4) => libc::AF_INET as u32,
+            Some(6) => libc::AF_INET6 as u32,
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "invalid ip packet version",
+                ))
+            }
+        };
+        let mut buf = Vec::with_capacity(packet.0.len() + UTUN_HEADER_SIZE);
+        buf.extend_from_slice(&family.to_be_bytes());
+        buf.extend_from_slice(&packet.0);
+        let written = unsafe { libc::write(self.fd.0, buf.as_ptr().cast(), buf.len()) };
+        if written < 0 {
+            return Err(Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    fn allocate_packet(&self, len: usize) -> Result<Self::Packet> {
+        Ok(TunPacket(vec![0u8; len]))
+    }
+
+    fn mtu(&self) -> usize {
+        self.mtu
+    }
+}
+
+pub struct TunPacket(Vec<u8>);
+
+impl Packet for TunPacket {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+fn create_utun_fd() -> Result<RawFd> {
+    unsafe {
+        let fd = libc::socket(libc::PF_SYSTEM, libc::SOCK_DGRAM, libc::SYSPROTO_CONTROL);
+        if fd < 0 {
+            return Err(Error::last_os_error());
+        }
+
+        let mut info: libc::ctl_info = mem::zeroed();
+        for (idx, byte) in UTUN_CONTROL_NAME.iter().enumerate() {
+            info.ctl_name[idx] = *byte as libc::c_char;
+        }
+        if libc::ioctl(fd, libc::CTLIOCGINFO, &mut info) < 0 {
+            let err = Error::last_os_error();
+            libc::close(fd);
+            return Err(err);
+        }
+
+        let mut addr: libc::sockaddr_ctl = mem::zeroed();
+        addr.sc_len = mem::size_of::<libc::sockaddr_ctl>() as u8;
+        addr.sc_family = libc::AF_SYSTEM as u8;
+        addr.ss_sysaddr = libc::AF_SYS_CONTROL as u16;
+        addr.sc_id = info.ctl_id;
+        addr.sc_unit = 0;
+
+        let ret = libc::connect(
+            fd,
+            (&addr as *const libc::sockaddr_ctl).cast(),
+            mem::size_of::<libc::sockaddr_ctl>() as libc::socklen_t,
+        );
+        if ret < 0 {
+            let err = Error::last_os_error();
+            libc::close(fd);
+            return Err(err);
+        }
+        Ok(fd)
+    }
+}
+
+fn set_nonblocking(fd: RawFd) -> Result<()> {
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        if flags < 0 {
+            return Err(Error::last_os_error());
+        }
+        if libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
+            return Err(Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+fn interface_name(fd: RawFd) -> Result<String> {
+    let mut name = [0u8; 64];
+    let mut len = name.len() as libc::socklen_t;
+    let ret = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SYSPROTO_CONTROL,
+            UTUN_OPT_IFNAME,
+            name.as_mut_ptr().cast(),
+            &mut len,
+        )
+    };
+    if ret < 0 {
+        return Err(Error::last_os_error());
+    }
+    let cstr = CStr::from_bytes_until_nul(&name)
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "utun interface name missing nul"))?;
+    Ok(cstr.to_string_lossy().into_owned())
+}

--- a/src/proxy/net_profiler.rs
+++ b/src/proxy/net_profiler.rs
@@ -113,7 +113,7 @@ async fn start_check_routine(
 async fn start_response(mut receiver: UnboundedReceiver<(IpAddr, bool)>, name: String) {
     log::info!("start response routine");
     cfg_if::cfg_if! {
-        if #[cfg(unix)] {
+        if #[cfg(target_os = "linux")] {
             let mut session:ipset::Session<ipset::types::HashIp> = ipset::Session::new(name);
             if let Err(err) = session.flush() {
                 log::error!("flush ipset failed:{:?}", err);
@@ -128,7 +128,7 @@ async fn start_response(mut receiver: UnboundedReceiver<(IpAddr, bool)>, name: S
         };
         log::warn!("{} should be bypassed", ip);
         cfg_if::cfg_if! {
-            if #[cfg(unix)] {
+            if #[cfg(target_os = "linux")] {
                 if let Err(err) = if add {
                     session.add(ip, &[])
                 } else {
@@ -152,7 +152,7 @@ async fn start_request(
     let config = ConfigBuilder::default().kind(ICMP::V4).build();
     let client = Arc::new(Client::new(&config).unwrap());
     cfg_if::cfg_if! {
-        if #[cfg(unix)] {
+        if #[cfg(target_os = "linux")] {
             let mut session:ipset::Session<ipset::types::HashIp> = ipset::Session::new(name);
         }
     }
@@ -164,7 +164,7 @@ async fn start_request(
             break;
         };
         cfg_if::cfg_if! {
-            if #[cfg(unix)] {
+            if #[cfg(target_os = "linux")] {
                 if let Ok(true) = session.test(ip) {
                     if let Err(err) = sender.send((ip, u16::MAX, u8::MAX)) {
                         log::error!("send local ping for {} failed:{}", ip, err);

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,11 +1,14 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(unix)] {
+    if #[cfg(target_os = "linux")] {
         mod unix;
         pub use self::unix::*;
     } else if #[cfg(windows)] {
         mod windows;
         pub use self::windows::*;
+    } else {
+        mod unsupported;
+        pub use self::unsupported::*;
     }
 }

--- a/src/sys/unsupported.rs
+++ b/src/sys/unsupported.rs
@@ -1,0 +1,28 @@
+use std::{any::Any, io::Result, net::SocketAddr};
+
+fn unsupported() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "proxy mode is not supported on this platform",
+    )
+}
+
+#[allow(dead_code)]
+pub fn set_mark<T: Any>(_socket: &T, _mark: u8) -> Result<()> {
+    Ok(())
+}
+
+pub fn set_socket_opts<T: Any>(_v4: bool, _is_udp: bool, _socket: &T) -> Result<()> {
+    Err(unsupported())
+}
+
+pub fn get_oridst_addr<T: Any>(_s: &T) -> Result<SocketAddr> {
+    Err(unsupported())
+}
+
+pub fn recv_from_with_destination<T: Any>(
+    _socket: &T,
+    _buf: &mut [u8],
+) -> Result<(usize, SocketAddr, SocketAddr)> {
+    Err(unsupported())
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,6 +27,8 @@ pub enum TrojanError {
     #[from(ignore)]
     Winapi(String),
     #[from(ignore)]
+    Custom(String),
+    #[from(ignore)]
     TxBreak(Option<std::io::Error>),
     #[from(ignore)]
     RxBreak(Option<std::io::Error>),

--- a/trojan-client/package.json
+++ b/trojan-client/package.json
@@ -9,6 +9,7 @@
     "serve:tauri": "set VITE_NETWORK_PROCESSOR=tauri && vite",
     "serve:native": "tauri dev",
     "build": "set VITE_NETWORK_PROCESSOR=tauri && vite build && tauri build",
+    "build:macos": "VITE_NETWORK_PROCESSOR=tauri vite build && tauri build --config src-tauri/tauri.macos.conf.json",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/trojan-client/src-tauri/Cargo.toml
+++ b/trojan-client/src-tauri/Cargo.toml
@@ -26,10 +26,12 @@ derive_more = { version = "2.0", features = ["from"] }
 backtrace = "0.3"
 log = "0.4"
 chrono = "0.4"
-wintool = { path = "../../wintool" }
 tauri-plugin-fs = "2.5.1"
 tauri-plugin-http = "2.5.9"
 tauri-plugin-shell = "2.3.5"
+
+[target.'cfg(windows)'.dependencies]
+wintool = { path = "../../wintool" }
 
 [features]
 # by default Tauri runs in production mode

--- a/trojan-client/src-tauri/build.rs
+++ b/trojan-client/src-tauri/build.rs
@@ -1,7 +1,11 @@
 fn main() {
     let profile = std::env::var("PROFILE").unwrap();
     let target = std::env::var("TARGET").unwrap();
-    let exe = if target.contains("windows") { ".exe" } else { "" };
+    let exe = if target.contains("windows") {
+        ".exe"
+    } else {
+        ""
+    };
     let file = format!("../../target/{}/trojan{}", profile, exe);
     println!("cargo:rerun-if-changed={}", file);
     let new_file = format!("libs/trojan-{}{}", target, exe);

--- a/trojan-client/src-tauri/build.rs
+++ b/trojan-client/src-tauri/build.rs
@@ -1,26 +1,29 @@
 fn main() {
     let profile = std::env::var("PROFILE").unwrap();
     let target = std::env::var("TARGET").unwrap();
-    let file = format!("../../target/{}/trojan.exe", profile);
+    let exe = if target.contains("windows") { ".exe" } else { "" };
+    let file = format!("../../target/{}/trojan{}", profile, exe);
     println!("cargo:rerun-if-changed={}", file);
-    let new_file = format!("libs/trojan-{}.exe", target);
+    let new_file = format!("libs/trojan-{}{}", target, exe);
     std::fs::create_dir_all("libs").unwrap();
     std::fs::copy(file, new_file).unwrap();
 
-    let wintun_arch = if target.contains("x86_64") {
-        "amd64"
-    } else if target.contains("i686") {
-        "x86"
-    } else if target.contains("aarch64") {
-        "arm64"
-    } else if target.contains("arm") {
-        "arm"
-    } else {
-        panic!("unsupported target for wintun.dll: {}", target);
-    };
-    let wintun_file = format!("../../wintun/bin/{}/wintun.dll", wintun_arch);
-    println!("cargo:rerun-if-changed={}", wintun_file);
-    std::fs::copy(wintun_file, "libs/wintun.dll").unwrap();
+    if target.contains("windows") {
+        let wintun_arch = if target.contains("x86_64") {
+            "amd64"
+        } else if target.contains("i686") {
+            "x86"
+        } else if target.contains("aarch64") {
+            "arm64"
+        } else if target.contains("arm") {
+            "arm"
+        } else {
+            panic!("unsupported target for wintun.dll: {}", target);
+        };
+        let wintun_file = format!("../../wintun/bin/{}/wintun.dll", wintun_arch);
+        println!("cargo:rerun-if-changed={}", wintun_file);
+        std::fs::copy(wintun_file, "libs/wintun.dll").unwrap();
+    }
 
     let mut windows = tauri_build::WindowsAttributes::new();
     windows = windows.app_manifest(

--- a/trojan-client/src-tauri/src/main.rs
+++ b/trojan-client/src-tauri/src/main.rs
@@ -120,7 +120,14 @@ impl TrojanProxy {
         Ok(())
     }
 
-    #[cfg(not(windows))]
+    #[cfg(target_os = "macos")]
+    fn update_dns(&mut self) -> Result<()> {
+        self.default_dns = self.config.trust_dns.clone();
+        self.explicit_dns = true;
+        Ok(())
+    }
+
+    #[cfg(all(not(windows), not(target_os = "macos")))]
     fn update_dns(&mut self) -> Result<()> {
         Err(Error::Custom(
             "VPN mode is not supported on this platform yet".to_string(),
@@ -128,10 +135,10 @@ impl TrojanProxy {
     }
 
     fn get_speed(&mut self) -> Result<(f32, f32)> {
-        let metadata = std::fs::metadata("logs\\wintun.status")?;
+        let metadata = std::fs::metadata(tun_status_file())?;
         let mod_time = metadata.modified()?;
         if mod_time > self.last_update {
-            let mut file = File::open("logs\\wintun.status")?;
+            let mut file = File::open(tun_status_file())?;
             let mut content = String::new();
             let _ = file.read_to_string(&mut content)?;
             let mut split = content.split(' ');
@@ -150,6 +157,26 @@ impl TrojanProxy {
         }
         Ok((self.rx_speed, self.tx_speed))
     }
+}
+
+#[cfg(windows)]
+fn tun_log_file() -> &'static str {
+    "logs\\wintun.log"
+}
+
+#[cfg(target_os = "macos")]
+fn tun_log_file() -> &'static str {
+    "logs/osxtun.log"
+}
+
+#[cfg(windows)]
+fn tun_status_file() -> &'static str {
+    "logs\\wintun.status"
+}
+
+#[cfg(target_os = "macos")]
+fn tun_status_file() -> &'static str {
+    "logs/osxtun.status"
 }
 
 type TrojanState = Arc<Mutex<TrojanProxy>>;
@@ -176,11 +203,13 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
             let config = state.lock().unwrap().config.clone();
             let default_dns = state.lock().unwrap().default_dns.clone() + ":53";
             let pool_size = config.pool_size.to_string();
+            #[cfg(windows)]
             let config_ipset = window
                 .app_handle()
                 .path()
                 .resolve("config/ipset.txt", BaseDirectory::Resource)
                 .unwrap();
+            #[cfg(windows)]
             let config_wintun = window
                 .app_handle()
                 .path()
@@ -188,29 +217,35 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
                 .unwrap();
             let mut args = vec![
                 "-l",
-                "logs\\wintun.log",
+                tun_log_file(),
                 "-L",
                 config.log_level_str(),
                 "-a",
                 "127.0.0.1:60080",
                 "-p",
                 config.server_auth.as_str(),
+                #[cfg(windows)]
                 "awintun",
+                #[cfg(target_os = "macos")]
+                "osxtun",
                 "-n",
                 config.iface_name.as_str(),
                 "-H",
                 config.server_domain.as_str(),
                 "-s",
-                "logs\\wintun.status",
+                tun_status_file(),
                 "--dns-server-addr",
                 default_dns.as_str(),
                 "-P",
                 pool_size.as_str(),
-                "-w",
-                config_wintun.to_str().unwrap(),
             ];
-            args.push("--route-ipset");
-            args.push(config_ipset.to_str().unwrap());
+            #[cfg(windows)]
+            {
+                args.push("-w");
+                args.push(config_wintun.to_str().unwrap());
+                args.push("--route-ipset");
+                args.push(config_ipset.to_str().unwrap());
+            }
             log::info!("{:?}", args);
             let mut rxs = HashMap::new();
             match window
@@ -231,6 +266,7 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
                     return;
                 }
             };
+            #[cfg(windows)]
             if state.lock().unwrap().config.enable_dns {
                 tokio::time::sleep(Duration::from_secs(10)).await;
                 let dns_listen = config.dns_listen.clone() + ":53";

--- a/trojan-client/src-tauri/src/main.rs
+++ b/trojan-client/src-tauri/src/main.rs
@@ -19,7 +19,7 @@ use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use tauri::{
     image::Image,
-    menu::{Menu, MenuItem},
+    menu::{Menu, MenuItem, PredefinedMenuItem},
     path::BaseDirectory,
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
     AppHandle, Emitter, Manager, RunEvent, State, WebviewWindow, WindowEvent, Wry,
@@ -30,6 +30,7 @@ use tauri_plugin_shell::{
     ShellExt,
 };
 
+#[cfg(windows)]
 use wintool::adapter::{get_dns_server, get_main_adapter_ip};
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -97,6 +98,7 @@ impl TrojanProxy {
         }
     }
 
+    #[cfg(windows)]
     fn update_dns(&mut self) -> Result<()> {
         let ret = get_dns_server();
         if ret.is_none() {
@@ -116,6 +118,13 @@ impl TrojanProxy {
         self.default_dns = dns;
         self.explicit_dns = set;
         Ok(())
+    }
+
+    #[cfg(not(windows))]
+    fn update_dns(&mut self) -> Result<()> {
+        Err(Error::Custom(
+            "VPN mode is not supported on this platform yet".to_string(),
+        ))
     }
 
     fn get_speed(&mut self) -> Result<(f32, f32)> {
@@ -438,7 +447,6 @@ fn init_config() -> Result<Config> {
     Ok(config)
 }
 
-
 fn load_domains() -> Result<Vec<String>> {
     let path = Path::new("config\\domain.txt");
     if !path.exists() {
@@ -517,6 +525,7 @@ fn remove_domain(key: String) {
         Err(err) => log::error!("load domains failed:{:?}", err),
     }
 }
+#[cfg(windows)]
 fn set_dns_server(state: &TrojanProxy) {
     if state.explicit_dns {
         wintool::adapter::set_dns_server(state.default_dns.clone());
@@ -524,6 +533,9 @@ fn set_dns_server(state: &TrojanProxy) {
         wintool::adapter::set_dns_server("".into());
     }
 }
+
+#[cfg(not(windows))]
+fn set_dns_server(_state: &TrojanProxy) {}
 
 fn quit_app(app: &AppHandle<Wry>) {
     let state: State<TrojanState> = app.state();
@@ -574,7 +586,15 @@ fn main() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_fs::init())
-        .invoke_handler(tauri::generate_handler![start, init, stop, update_speed, search_domain, add_domain, remove_domain])
+        .invoke_handler(tauri::generate_handler![
+            start,
+            init,
+            stop,
+            update_speed,
+            search_domain,
+            add_domain,
+            remove_domain
+        ])
         .plugin(
             tauri_plugin_log::Builder::default()
                 .targets([

--- a/trojan-client/src-tauri/tauri.conf.json
+++ b/trojan-client/src-tauri/tauri.conf.json
@@ -15,7 +15,9 @@
       "libs/trojan"
     ],
     "icon": [
-      "icons/icon.ico"
+      "icons/icon.ico",
+      "icons/icon.icns",
+      "icons/icon.png"
     ],
     "windows": {
       "certificateThumbprint": null,
@@ -46,7 +48,7 @@
   "productName": "trojan-client",
   "mainBinaryName": "app",
   "version": "0.4.0",
-  "identifier": "com.bmshi.trojan.windows",
+  "identifier": "com.bmshi.trojan.client",
   "plugins": {},
   "app": {
     "windows": [

--- a/trojan-client/src-tauri/tauri.macos.conf.json
+++ b/trojan-client/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,9 @@
+{
+  "bundle": {
+    "resources": [
+      "config/domain.txt",
+      "config/ipset.txt",
+      "config/hosts.txt"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a macOS trojan-client build workflow and Tauri macOS config
- gate Linux/Windows-specific pieces so macOS builds can compile
- add macOS osxtun routing and TUN scaffolding

## Validation
- `cargo check --workspace` passes on Windows, with existing warnings

## Notes
- local untracked mobile screenshots/logs were left out of this PR
- this is draft while waiting for Gemini review feedback