### PR TITLE
[codex] Make Android tun polling reactive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,6 +2135,7 @@ dependencies = [
  "webpki-roots",
  "widestring",
  "winapi",
+ "windows-sys 0.52.0",
  "wintool",
  "wintun",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ env_logger = "0.11"
 wintun = "0.5.1"
 wintool = { path = "wintool" }
 winapi = { version = "0.3", features = ["netioapi", "impl-debug", "impl-default", "combaseapi", "ipifcons", "consoleapi"] }
+windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [target.'cfg(not(windows))'.dependencies]
 backtrace-on-stack-overflow = "0.3"

--- a/async_smoltcp/Cargo.toml
+++ b/async_smoltcp/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 [dependencies]
 smoltcp = { version = "0.13", features = [] }
 bytes = "1.11"
-tokio = { version = "1.52", features = [] }
+tokio = { version = "1.52", features = ["sync"] }
 tokio-util = "0.7"
 log = "0.4"

--- a/async_smoltcp/src/device.rs
+++ b/async_smoltcp/src/device.rs
@@ -153,14 +153,7 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
         self.interface
             .as_mut()?
             .poll_delay(Instant::now(), &self.sockets)
-            .map(|delay| {
-                let millis = delay.total_millis();
-                if millis <= 0 {
-                    std::time::Duration::ZERO
-                } else {
-                    std::time::Duration::from_millis(millis as u64)
-                }
-            })
+            .map(|delay| std::time::Duration::from_millis(delay.total_millis()))
     }
 
     pub fn add_black_ip(&mut self, server_addr: impl Into<IpAddr>) {

--- a/async_smoltcp/src/device.rs
+++ b/async_smoltcp/src/device.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     net::IpAddr,
+    sync::Arc,
     time::SystemTime,
 };
 
@@ -19,7 +20,10 @@ use smoltcp::{
         Ipv4Packet, Ipv6Packet, TcpPacket, UdpPacket,
     },
 };
-use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::{
+    mpsc::{channel, Receiver, Sender},
+    Notify,
+};
 
 use crate::{tcp::TcpStream, Packet, Tun, TypeConverter};
 
@@ -27,6 +31,12 @@ pub struct Traffic {
     rx_bytes: usize,
     tx_bytes: usize,
     begin_traffic: std::time::Instant,
+}
+
+#[derive(Default)]
+struct EgressState {
+    made_progress: bool,
+    has_pending: bool,
 }
 
 impl Traffic {
@@ -74,6 +84,7 @@ pub struct TunDevice<'a, T: Tun> {
     last_shrink: std::time::Instant,
 
     tcp_response: HashMap<IpEndpoint, VecDeque<BytesMut>>,
+    wake: Arc<Notify>,
 }
 
 fn is_private_v4(addr: IpAddress) -> bool {
@@ -127,10 +138,29 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
             last_shrink: std::time::Instant::now(),
 
             tcp_response: Default::default(),
+            wake: Arc::new(Notify::new()),
         };
         let interface = device.create_interface();
         device.interface.replace(interface);
         device
+    }
+
+    pub fn notifier(&self) -> Arc<Notify> {
+        self.wake.clone()
+    }
+
+    pub fn poll_delay(&mut self) -> Option<std::time::Duration> {
+        self.interface
+            .as_mut()?
+            .poll_delay(Instant::now(), &self.sockets)
+            .map(|delay| {
+                let millis = delay.total_millis();
+                if millis <= 0 {
+                    std::time::Duration::ZERO
+                } else {
+                    std::time::Duration::from_millis(millis as u64)
+                }
+            })
     }
 
     pub fn add_black_ip(&mut self, server_addr: impl Into<IpAddr>) {
@@ -223,6 +253,7 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
                 self.tcp_sender.clone(),
                 source,
                 self.tcp_ip2handle.get(&source).unwrap().1,
+                self.wake.clone(),
             );
             streams.push(stream);
         }
@@ -234,7 +265,12 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
         for target in std::mem::take(&mut self.new_udp) {
             let (sender, receiver) = channel(self.channel_buffer_size);
             self.udp_req_senders.insert(target, sender);
-            let socket = crate::udp::UdpSocket::new(target, receiver, self.udp_sender.clone());
+            let socket = crate::udp::UdpSocket::new(
+                target,
+                receiver,
+                self.udp_sender.clone(),
+                self.wake.clone(),
+            );
             sockets.push(socket);
         }
         sockets
@@ -282,21 +318,36 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
             self.udp_ip2handle.len(), self.tcp_req_senders.len(), self.udp_req_senders.len());
     }
 
-    pub fn poll(&mut self) -> (Vec<TcpStream>, Vec<crate::udp::UdpSocket>) {
+    pub fn maintenance(&mut self) {
+        if self.last_shrink.elapsed().as_secs() > 1 {
+            self.shrink_maps();
+            self.last_shrink = std::time::Instant::now();
+        }
+    }
+
+    fn poll_interface(&mut self) {
         let mut interface = self.interface.take().unwrap();
         let sockets = &mut self.sockets as *mut SocketSet;
         interface.poll(smoltcp::time::Instant::now(), self, unsafe {
             &mut *sockets
         });
         self.interface.replace(interface);
-        let tcp = self.accept_tcp();
-        let udp = self.accept_udp();
-        self.process_ingress();
+    }
+
+    pub fn poll(&mut self) -> (Vec<TcpStream>, Vec<crate::udp::UdpSocket>) {
         self.process_egress();
-        if self.last_shrink.elapsed().as_secs() > 1 {
-            self.shrink_maps();
-            self.last_shrink = std::time::Instant::now();
+        self.poll_interface();
+        let mut tcp = self.accept_tcp();
+        let mut udp = self.accept_udp();
+        self.process_ingress();
+        let egress = self.process_egress();
+        if egress.made_progress || egress.has_pending {
+            self.poll_interface();
+            tcp.extend(self.accept_tcp());
+            udp.extend(self.accept_udp());
+            self.process_ingress();
         }
+        self.maintenance();
         (tcp, udp)
     }
 
@@ -314,13 +365,13 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
                     if let Some(source) = socket.remote_endpoint() {
                         let sender = self.tcp_req_senders.get(&source).unwrap();
                         while socket.can_recv() && sender.capacity() > 0 {
-                            log::info!("dispatch ingress tcp {} {}", source, socket.state());
+                            log::debug!("dispatch ingress tcp {} {}", source, socket.state());
                             let mut buffer = BytesMut::with_capacity(socket.recv_queue());
                             unsafe {
                                 buffer.set_len(socket.recv_queue());
                             }
                             if let Ok(n) = socket.recv_slice(buffer.as_mut()) {
-                                log::info!("receive {} bytes from {}", n, source);
+                                log::debug!("receive {} bytes from {}", n, source);
                                 if n != buffer.len() {
                                     log::error!("tcp recv_slice do not drain the buffer");
                                     unsafe {
@@ -357,7 +408,7 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
                     let target: IpEndpoint = socket.endpoint().convert();
                     let sender = self.udp_req_senders.get(&target).unwrap();
                     while socket.can_recv() && sender.capacity() > 0 {
-                        log::info!("dispatch udp {}", target);
+                        log::debug!("dispatch udp {}", target);
                         let mut buffer = BytesMut::with_capacity(self.mtu);
                         unsafe {
                             buffer.set_len(self.mtu);
@@ -393,7 +444,8 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
         }
     }
 
-    fn process_egress(&mut self) {
+    fn process_egress(&mut self) -> EgressState {
+        let mut state = EgressState::default();
         let mut response = std::mem::take(&mut self.tcp_response);
         while let Ok((source, data)) = self.tcp_receiver.try_recv() {
             response.entry(source).or_default().push_back(data);
@@ -404,11 +456,12 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
                 to_be_removed.push(*source);
                 continue;
             }
-            log::info!("get tcp socket:{}", source);
+            log::debug!("get tcp socket:{}", source);
             let socket = self.get_tcp_socket(*source);
             while let Some(mut data) = packets.pop_front() {
                 if !data.is_empty() {
                     if let Ok(n) = socket.send_slice(data.as_ref()) {
+                        state.made_progress |= n > 0;
                         data.advance(n);
                         if data.is_empty() {
                             continue;
@@ -431,6 +484,7 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
         for source in to_be_removed {
             response.remove(&source);
         }
+        state.has_pending = response.values().any(|packets| !packets.is_empty());
         self.tcp_response = response;
 
         let mut response: HashMap<IpEndpoint, Vec<(IpEndpoint, BytesMut)>> = HashMap::new();
@@ -441,19 +495,26 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
             if !self.udp_ip2handle.contains_key(&target) {
                 continue;
             }
-            log::info!("get udp socket:{}", target);
+            log::debug!("get udp socket:{}", target);
             let socket = self.get_udp_socket(target);
             let mut remove = false;
             for (source, data) in packets {
-                if data.is_empty() || socket.send_slice(data.as_ref(), source).is_err() {
+                if data.is_empty() {
                     remove = true;
                     break;
+                }
+                if socket.send_slice(data.as_ref(), source).is_err() {
+                    remove = true;
+                    break;
+                } else {
+                    state.made_progress = true;
                 }
             }
             if remove {
                 self.remove_udp(target);
             }
         }
+        state
     }
 
     fn remove_tcp_handle(&mut self, handle: SocketHandle) {
@@ -595,8 +656,14 @@ impl<'a, T: Tun> smoltcp::phy::TxToken for TxToken<'a, T> {
 }
 
 impl<'b, T: Tun + Clone> Device for TunDevice<'b, T> {
-    type RxToken<'a> = RxToken<T> where Self: 'a;
-    type TxToken<'a> = TxToken<'a, T> where Self: 'a;
+    type RxToken<'a>
+        = RxToken<T>
+    where
+        Self: 'a;
+    type TxToken<'a>
+        = TxToken<'a, T>
+    where
+        Self: 'a;
 
     fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         self.tun.receive().unwrap().map(|packet| {
@@ -623,5 +690,62 @@ impl<'b, T: Tun + Clone> Device for TunDevice<'b, T> {
         dc.medium = Medium::Ip;
         dc.max_transmission_unit = self.mtu;
         dc
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Result;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestTun;
+
+    struct TestPacket(Vec<u8>);
+
+    impl Tun for TestTun {
+        type Packet = TestPacket;
+
+        fn receive(&self) -> Result<Option<Self::Packet>> {
+            Ok(None)
+        }
+
+        fn send(&self, _: Self::Packet) -> Result<()> {
+            Ok(())
+        }
+
+        fn allocate_packet(&self, len: usize) -> Result<Self::Packet> {
+            Ok(TestPacket(vec![0; len]))
+        }
+
+        fn mtu(&self) -> usize {
+            1500
+        }
+    }
+
+    impl Packet for TestPacket {
+        fn as_mut(&mut self) -> &mut [u8] {
+            self.0.as_mut_slice()
+        }
+
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_slice()
+        }
+
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+    }
+
+    #[test]
+    fn maintenance_can_run_without_polling_stack() {
+        let mut device = TunDevice::new(TestTun);
+        let before = std::time::Instant::now() - std::time::Duration::from_secs(2);
+        device.last_shrink = before;
+
+        device.maintenance();
+
+        assert!(device.last_shrink > before);
     }
 }

--- a/async_smoltcp/src/tcp.rs
+++ b/async_smoltcp/src/tcp.rs
@@ -2,6 +2,7 @@ use std::{
     io::Error,
     net::SocketAddr,
     pin::Pin,
+    sync::Arc,
     task::{ready, Context, Poll},
 };
 
@@ -9,7 +10,10 @@ use bytes::{Buf, BytesMut};
 use smoltcp::wire::IpEndpoint;
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
-    sync::mpsc::{Receiver, Sender},
+    sync::{
+        mpsc::{Receiver, Sender},
+        Notify,
+    },
 };
 use tokio_util::sync::PollSender;
 
@@ -33,6 +37,7 @@ impl TcpReadHalf {
 pub struct TcpWriteHalf {
     sender: PollSender<(IpEndpoint, BytesMut)>,
     local_addr: IpEndpoint,
+    wake: Arc<Notify>,
 }
 
 pub struct TcpStream {
@@ -48,6 +53,7 @@ impl TcpStream {
         sender: Sender<(IpEndpoint, BytesMut)>,
         local_addr: IpEndpoint,
         peer_addr: IpEndpoint,
+        wake: Arc<Notify>,
     ) -> Self {
         Self {
             reader: TcpReadHalf {
@@ -58,6 +64,7 @@ impl TcpStream {
             writer: TcpWriteHalf {
                 sender: PollSender::new(sender),
                 local_addr,
+                wake,
             },
             local_addr,
             peer_addr,
@@ -111,6 +118,7 @@ impl AsyncWrite for TcpWriteHalf {
             if let Err(err) = pin.sender.send_item((pin.local_addr, buf.into())) {
                 log::error!("tcp send response failed: {}", err);
             } else {
+                pin.wake.notify_one();
                 return Poll::Ready(Ok(buf.len()));
             }
         }
@@ -154,5 +162,51 @@ impl AsyncWrite for TcpStream {
         let pin = self.get_mut();
         pin.reader.receiver.close();
         Pin::new(&mut pin.writer).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+    };
+
+    use smoltcp::wire::{IpAddress, IpEndpoint};
+    use tokio::sync::{mpsc::channel, Notify};
+
+    use super::*;
+
+    fn noop_waker() -> Waker {
+        unsafe fn clone(_: *const ()) -> RawWaker {
+            RawWaker::new(std::ptr::null(), &VTABLE)
+        }
+        unsafe fn wake(_: *const ()) {}
+        unsafe fn wake_by_ref(_: *const ()) {}
+        unsafe fn drop(_: *const ()) {}
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+        unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+    }
+
+    #[test]
+    fn tcp_write_notifies_device_after_queueing_egress() {
+        let (sender, mut receiver) = channel(1);
+        let wake = std::sync::Arc::new(Notify::new());
+        let mut writer = TcpWriteHalf {
+            sender: PollSender::new(sender),
+            local_addr: IpEndpoint::new(IpAddress::v4(10, 10, 10, 1), 12345),
+            wake: wake.clone(),
+        };
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let written = Pin::new(&mut writer).poll_write(&mut cx, b"packet");
+
+        assert!(matches!(written, Poll::Ready(Ok(6))));
+        assert!(receiver.try_recv().is_ok());
+
+        let mut notified = Box::pin(wake.notified());
+        assert!(matches!(notified.as_mut().poll(&mut cx), Poll::Ready(())));
     }
 }

--- a/async_smoltcp/src/udp.rs
+++ b/async_smoltcp/src/udp.rs
@@ -1,8 +1,11 @@
-use std::{io::ErrorKind, net::SocketAddr};
+use std::{io::ErrorKind, net::SocketAddr, sync::Arc};
 
 use bytes::BytesMut;
 use smoltcp::wire::IpEndpoint;
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::{
+    mpsc::{Receiver, Sender},
+    Notify,
+};
 
 use crate::TypeConverter;
 
@@ -17,11 +20,16 @@ impl UdpSocket {
         peer_addr: IpEndpoint,
         receiver: Receiver<(IpEndpoint, BytesMut)>,
         sender: Sender<(IpEndpoint, IpEndpoint, BytesMut)>,
+        wake: Arc<Notify>,
     ) -> Self {
         Self {
             peer_addr,
             receiver,
-            write_half: UdpWriteHalf { sender, peer_addr },
+            write_half: UdpWriteHalf {
+                sender,
+                peer_addr,
+                wake,
+            },
         }
     }
 
@@ -67,6 +75,7 @@ impl UdpSocket {
 pub struct UdpWriteHalf {
     sender: Sender<(IpEndpoint, IpEndpoint, BytesMut)>,
     peer_addr: IpEndpoint,
+    wake: Arc<Notify>,
 }
 
 impl UdpWriteHalf {
@@ -82,6 +91,8 @@ impl UdpWriteHalf {
             .await
         {
             log::error!("send udp response failed:{}", err);
+        } else {
+            self.wake.notify_one();
         }
         Ok(len)
     }
@@ -96,5 +107,52 @@ impl UdpWriteHalf {
 
     pub fn peer_addr_std(&self) -> SocketAddr {
         self.peer_addr.convert()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+    };
+
+    use smoltcp::wire::{IpAddress, IpEndpoint};
+    use tokio::sync::{mpsc::channel, Notify};
+
+    use super::*;
+
+    fn noop_waker() -> Waker {
+        unsafe fn clone(_: *const ()) -> RawWaker {
+            RawWaker::new(std::ptr::null(), &VTABLE)
+        }
+        unsafe fn wake(_: *const ()) {}
+        unsafe fn wake_by_ref(_: *const ()) {}
+        unsafe fn drop(_: *const ()) {}
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+        unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+    }
+
+    #[test]
+    fn udp_write_notifies_device_after_queueing_egress() {
+        let (sender, mut receiver) = channel(1);
+        let wake = std::sync::Arc::new(Notify::new());
+        let writer = UdpWriteHalf {
+            sender,
+            peer_addr: IpEndpoint::new(IpAddress::v4(8, 8, 8, 8), 53),
+            wake: wake.clone(),
+        };
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut send = Box::pin(writer.send_to(
+            b"packet",
+            IpEndpoint::new(IpAddress::v4(10, 10, 10, 1), 12345),
+        ));
+
+        assert!(matches!(send.as_mut().poll(&mut cx), Poll::Ready(Ok(6))));
+        assert!(receiver.try_recv().is_ok());
+
+        let mut notified = Box::pin(wake.notified());
+        assert!(matches!(notified.as_mut().poll(&mut cx), Poll::Ready(())));
     }
 }

--- a/mobile/src-tauri/Cargo.lock
+++ b/mobile/src-tauri/Cargo.lock
@@ -1910,6 +1910,7 @@ dependencies = [
  "itertools",
  "jni",
  "lazy_static",
+ "libc",
  "log",
  "mio 0.8.9",
  "rayon",

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri-plugin-shell = "2.3.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
+libc = "0.2"
 lazy_static = "1.4"
 derive_more = "0.99"
 smoltcp = { version = "0.13", features = [] }

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ socket2 = "0.5"
 sha2 = "0.10"
 hex = "0.4"
 mio = { version = "0.8", features = ["net", "os-poll"] }
-tokio = { version = "1.34", features = ["net", "macros"] }
+tokio = { version = "1.34", features = ["net", "macros", "rt", "time", "sync", "io-util"] }
 async_smoltcp = { path = "../../async_smoltcp" }
 async_rustls = { path = "../../tokio_rustls" }
 

--- a/mobile/src-tauri/src/atun/mod.rs
+++ b/mobile/src-tauri/src/atun/mod.rs
@@ -4,14 +4,19 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use bytes::BytesMut;
 use rustls::{ClientConfig, ClientConnection, RootCertStore};
 use rustls_pki_types::ServerName;
 use sha2::{Digest, Sha224};
-use tokio::{runtime::Builder, spawn, sync::mpsc::channel};
+use tokio::{
+    runtime::Builder,
+    spawn,
+    sync::mpsc::channel,
+    time::{interval, MissedTickBehavior},
+};
 
 use async_rustls::TlsClientStream;
 use async_smoltcp::TunDevice;
@@ -52,6 +57,20 @@ fn digest_pass(pass: &String) -> String {
 
 fn show_info(level: &String) -> bool {
     level == "Debug" || level == "Info" || level == "Trace"
+}
+
+async fn wait_stack_delay(delay: Option<Duration>) {
+    if let Some(delay) = delay {
+        tokio::time::sleep(delay).await;
+    } else {
+        std::future::pending::<()>().await;
+    }
+}
+
+enum PollTrigger {
+    TunReady,
+    DeviceWake,
+    StackTimer,
 }
 
 pub async fn async_run(
@@ -99,7 +118,7 @@ pub async fn async_run(
             .with_no_client_auth(),
     );
 
-    let mut device = TunDevice::new(session);
+    let mut device = TunDevice::new(session.clone());
     device.add_white_ip(dns_addr.ip());
 
     let trusted_addr = (context.options.trusted_dns.clone() + ":53").parse()?;
@@ -123,9 +142,60 @@ pub async fn async_run(
         close_sender.clone(),
     ));
 
-    let mut last_speed_time = Instant::now();
+    let mut tun_ready = platform::TunReady::new(&session)?;
+    let device_wake = device.notifier();
+    let speed_update_ms = (context.options.speed_update_ms as u64).max(1);
+    let mut speed_tick = interval(Duration::from_millis(speed_update_ms));
+    speed_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    speed_tick.tick().await;
+    let mut shutdown_tick = interval(Duration::from_millis(250));
+    shutdown_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    shutdown_tick.tick().await;
+    let mut maintenance_tick = interval(Duration::from_secs(1));
+    maintenance_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    maintenance_tick.tick().await;
+
     while running.load(Ordering::Relaxed) {
+        let stack_delay = device.poll_delay();
+        let poll_trigger = tokio::select! {
+            result = tun_ready.readable() => {
+                result?;
+                Some(PollTrigger::TunReady)
+            }
+            _ = device_wake.notified() => Some(PollTrigger::DeviceWake),
+            _ = wait_stack_delay(stack_delay) => Some(PollTrigger::StackTimer),
+            _ = speed_tick.tick() => {
+                let (rx_speed, tx_speed) = device.calculate_speed();
+                let (rx_speed, rx_unit) = get_speed_and_unit(rx_speed);
+                let (tx_speed, tx_unit) = get_speed_and_unit(tx_speed);
+                emit_event(
+                    EventType::UpdateSpeed,
+                    format!(
+                        "上行速度:{:.1}{}/s, 下行速度:{:.1}{}/s",
+                        rx_speed, rx_unit, tx_speed, tx_unit
+                    ),
+                )?;
+                None
+            }
+            _ = maintenance_tick.tick() => {
+                device.maintenance();
+                None
+            }
+            _ = shutdown_tick.tick() => None,
+        };
+
+        let Some(poll_trigger) = poll_trigger else {
+            continue;
+        };
+
+        if !running.load(Ordering::Relaxed) {
+            continue;
+        }
+
         let (tcp_streams, udp_sockets) = device.poll();
+        if matches!(poll_trigger, PollTrigger::TunReady) {
+            tun_ready.clear_ready().await?;
+        }
 
         for stream in tcp_streams {
             log::info!(
@@ -159,21 +229,6 @@ pub async fn async_run(
                 spawn(start_udp(socket, data_sender.clone(), close_sender.clone()));
             }
         }
-
-        if last_speed_time.elapsed().as_millis() >= context.options.speed_update_ms {
-            let (rx_speed, tx_speed) = device.calculate_speed();
-            let (rx_speed, rx_unit) = get_speed_and_unit(rx_speed);
-            let (tx_speed, tx_unit) = get_speed_and_unit(tx_speed);
-            emit_event(
-                EventType::UpdateSpeed,
-                format!(
-                    "上行速度:{:.1}{}/s, 下行速度:{:.1}{}/s",
-                    rx_speed, rx_unit, tx_speed, tx_unit
-                ),
-            )?;
-            last_speed_time = std::time::Instant::now();
-        }
-        tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
     Ok(())

--- a/mobile/src-tauri/src/atun/mod.rs
+++ b/mobile/src-tauri/src/atun/mod.rs
@@ -67,12 +67,6 @@ async fn wait_stack_delay(delay: Option<Duration>) {
     }
 }
 
-enum PollTrigger {
-    TunReady,
-    DeviceWake,
-    StackTimer,
-}
-
 pub async fn async_run(
     fd: i32,
     dns: String,
@@ -148,22 +142,19 @@ pub async fn async_run(
     let mut speed_tick = interval(Duration::from_millis(speed_update_ms));
     speed_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
     speed_tick.tick().await;
-    let mut shutdown_tick = interval(Duration::from_millis(250));
-    shutdown_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
-    shutdown_tick.tick().await;
     let mut maintenance_tick = interval(Duration::from_secs(1));
     maintenance_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
     maintenance_tick.tick().await;
 
     while running.load(Ordering::Relaxed) {
         let stack_delay = device.poll_delay();
-        let poll_trigger = tokio::select! {
+        let poll_stack = tokio::select! {
             result = tun_ready.readable() => {
                 result?;
-                Some(PollTrigger::TunReady)
+                true
             }
-            _ = device_wake.notified() => Some(PollTrigger::DeviceWake),
-            _ = wait_stack_delay(stack_delay) => Some(PollTrigger::StackTimer),
+            _ = device_wake.notified() => true,
+            _ = wait_stack_delay(stack_delay) => true,
             _ = speed_tick.tick() => {
                 let (rx_speed, tx_speed) = device.calculate_speed();
                 let (rx_speed, rx_unit) = get_speed_and_unit(rx_speed);
@@ -175,27 +166,19 @@ pub async fn async_run(
                         rx_speed, rx_unit, tx_speed, tx_unit
                     ),
                 )?;
-                None
+                false
             }
             _ = maintenance_tick.tick() => {
                 device.maintenance();
-                None
+                false
             }
-            _ = shutdown_tick.tick() => None,
         };
 
-        let Some(poll_trigger) = poll_trigger else {
-            continue;
-        };
-
-        if !running.load(Ordering::Relaxed) {
+        if !running.load(Ordering::Relaxed) || !poll_stack {
             continue;
         }
 
         let (tcp_streams, udp_sockets) = device.poll();
-        if matches!(poll_trigger, PollTrigger::TunReady) {
-            tun_ready.clear_ready().await?;
-        }
 
         for stream in tcp_streams {
             log::info!(

--- a/mobile/src-tauri/src/platform/android.rs
+++ b/mobile/src-tauri/src/platform/android.rs
@@ -3,7 +3,7 @@ use std::{
     io::{ErrorKind, Read, Write},
     mem::ManuallyDrop,
     ops::Deref,
-    os::fd::{FromRawFd, OwnedFd},
+    os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, LockResult, RwLock, RwLockReadGuard, RwLockWriteGuard,
@@ -407,6 +407,18 @@ pub struct Session {
     show_info: bool,
 }
 
+struct RawTunFd(RawFd);
+
+impl AsRawFd for RawTunFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0
+    }
+}
+
+pub struct TunReady {
+    fd: tokio::io::unix::AsyncFd<RawTunFd>,
+}
+
 pub struct Packet {
     data: Vec<u8>,
 }
@@ -422,6 +434,30 @@ impl Session {
                 show_info,
             }
         }
+    }
+
+    fn raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
+    }
+}
+
+impl TunReady {
+    pub fn new(session: &Session) -> std::io::Result<Self> {
+        Ok(Self {
+            fd: tokio::io::unix::AsyncFd::new(RawTunFd(session.raw_fd()))?,
+        })
+    }
+
+    pub async fn readable(&mut self) -> std::io::Result<()> {
+        let guard = self.fd.readable().await?;
+        drop(guard);
+        Ok(())
+    }
+
+    pub async fn clear_ready(&mut self) -> std::io::Result<()> {
+        let mut guard = self.fd.readable().await?;
+        guard.clear_ready();
+        Ok(())
     }
 }
 

--- a/mobile/src-tauri/src/platform/android.rs
+++ b/mobile/src-tauri/src/platform/android.rs
@@ -443,22 +443,31 @@ impl Session {
 
 impl TunReady {
     pub fn new(session: &Session) -> std::io::Result<Self> {
+        let fd = session.raw_fd();
+        set_nonblocking(fd)?;
         Ok(Self {
-            fd: tokio::io::unix::AsyncFd::new(RawTunFd(session.raw_fd()))?,
+            fd: tokio::io::unix::AsyncFd::new(RawTunFd(fd))?,
         })
     }
 
     pub async fn readable(&mut self) -> std::io::Result<()> {
-        let guard = self.fd.readable().await?;
-        drop(guard);
-        Ok(())
-    }
-
-    pub async fn clear_ready(&mut self) -> std::io::Result<()> {
         let mut guard = self.fd.readable().await?;
         guard.clear_ready();
         Ok(())
     }
+}
+
+fn set_nonblocking(fd: RawFd) -> std::io::Result<()> {
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        if flags < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    Ok(())
 }
 
 impl Tun for Session {

--- a/mobile/src-tauri/src/platform/fallback.rs
+++ b/mobile/src-tauri/src/platform/fallback.rs
@@ -31,10 +31,6 @@ impl TunReady {
         self.interval.tick().await;
         Ok(())
     }
-
-    pub async fn clear_ready(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
 }
 
 impl async_smoltcp::Tun for Session {

--- a/mobile/src-tauri/src/platform/fallback.rs
+++ b/mobile/src-tauri/src/platform/fallback.rs
@@ -1,7 +1,13 @@
 use crate::{types::VpnError, InstalledApp};
 
+use std::time::Duration;
+
 pub struct Session {
     mtu: usize,
+}
+
+pub struct TunReady {
+    interval: tokio::time::Interval,
 }
 
 pub struct Packet {
@@ -11,6 +17,23 @@ pub struct Packet {
 impl Session {
     pub fn new(_: i32, mtu: usize, _: bool) -> Self {
         Self { mtu }
+    }
+}
+
+impl TunReady {
+    pub fn new(_: &Session) -> std::io::Result<Self> {
+        Ok(Self {
+            interval: tokio::time::interval(Duration::from_millis(10)),
+        })
+    }
+
+    pub async fn readable(&mut self) -> std::io::Result<()> {
+        self.interval.tick().await;
+        Ok(())
+    }
+
+    pub async fn clear_ready(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 

--- a/mobile/src-tauri/src/platform/ios.rs
+++ b/mobile/src-tauri/src/platform/ios.rs
@@ -31,10 +31,6 @@ impl TunReady {
         self.interval.tick().await;
         Ok(())
     }
-
-    pub async fn clear_ready(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
 }
 
 impl async_smoltcp::Tun for Session {

--- a/mobile/src-tauri/src/platform/ios.rs
+++ b/mobile/src-tauri/src/platform/ios.rs
@@ -1,7 +1,13 @@
 use crate::{types::VpnError, InstalledApp};
 
+use std::time::Duration;
+
 pub struct Session {
     mtu: usize,
+}
+
+pub struct TunReady {
+    interval: tokio::time::Interval,
 }
 
 pub struct Packet {
@@ -11,6 +17,23 @@ pub struct Packet {
 impl Session {
     pub fn new(_: i32, mtu: usize, _: bool) -> Self {
         Self { mtu }
+    }
+}
+
+impl TunReady {
+    pub fn new(_: &Session) -> std::io::Result<Self> {
+        Ok(Self {
+            interval: tokio::time::interval(Duration::from_millis(10)),
+        })
+    }
+
+    pub async fn readable(&mut self) -> std::io::Result<()> {
+        self.interval.tick().await;
+        Ok(())
+    }
+
+    pub async fn clear_ready(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 

--- a/src/awintun/mod.rs
+++ b/src/awintun/mod.rs
@@ -1,21 +1,37 @@
-use std::{
-    fs::OpenOptions,
-    io::Write,
-    net::SocketAddr,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{fs::OpenOptions, io::Write, net::SocketAddr, sync::Arc, time::Duration};
 
 use async_smoltcp::{Tun, TunDevice};
 use bytes::BytesMut;
 use rustls::{ClientConfig, RootCertStore};
 use rustls_pki_types::ServerName;
-use tokio::{net::TcpStream, runtime::Runtime, spawn, sync::mpsc::channel};
+use tokio::{
+    net::TcpStream,
+    runtime::Runtime,
+    spawn,
+    sync::{mpsc::channel, Notify},
+    time::{interval, MissedTickBehavior},
+};
 use tokio_rustls::{client::TlsStream, TlsConnector};
 use types::Result;
 
 #[cfg(windows)]
-use std::net::Ipv4Addr;
+use std::{
+    net::Ipv4Addr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Condvar, Mutex,
+    },
+    thread,
+};
+
+#[cfg(target_os = "macos")]
+use std::os::fd::{AsRawFd, RawFd};
+
+#[cfg(windows)]
+use windows_sys::Win32::{
+    Foundation::{CloseHandle, FALSE, HANDLE, WAIT_FAILED, WAIT_OBJECT_0},
+    System::Threading::{CreateEventW, SetEvent, WaitForMultipleObjects, INFINITE},
+};
 #[cfg(windows)]
 use wintool::adapter::get_main_adapter_gwif;
 #[cfg(windows)]
@@ -47,6 +63,196 @@ mod tcp;
 #[cfg(windows)]
 mod tun;
 mod udp;
+
+#[cfg(windows)]
+type PlatformTunReady = WintunReady;
+#[cfg(target_os = "macos")]
+type PlatformTunReady = OsxTunReady;
+
+#[cfg(windows)]
+struct WintunReady {
+    wake: Arc<Notify>,
+    state: Arc<ReadyState>,
+    shutdown_event: HANDLE,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+#[cfg(windows)]
+struct ReadyState {
+    armed: Mutex<bool>,
+    shutdown: AtomicBool,
+    condvar: Condvar,
+}
+
+#[cfg(windows)]
+impl WintunReady {
+    fn new(session: Arc<wintun::Session>) -> Result<Self> {
+        let read_event = session.get_read_wait_event()?;
+        let shutdown_event = unsafe { CreateEventW(std::ptr::null(), 1, 0, std::ptr::null()) };
+        if shutdown_event == 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+
+        let wake = Arc::new(Notify::new());
+        let state = Arc::new(ReadyState {
+            armed: Mutex::new(true),
+            shutdown: AtomicBool::new(false),
+            condvar: Condvar::new(),
+        });
+        let thread_wake = wake.clone();
+        let thread_state = state.clone();
+        let thread = match thread::Builder::new()
+            .name("wintun-ready".to_string())
+            .spawn(move || {
+                let _session = session;
+                let handles = [read_event, shutdown_event];
+
+                loop {
+                    let result = unsafe {
+                        WaitForMultipleObjects(
+                            handles.len() as u32,
+                            handles.as_ptr(),
+                            FALSE,
+                            INFINITE,
+                        )
+                    };
+                    match result {
+                        WAIT_OBJECT_0 => {
+                            {
+                                let mut armed = thread_state
+                                    .armed
+                                    .lock()
+                                    .unwrap_or_else(|error| error.into_inner());
+                                *armed = false;
+                            }
+                            thread_wake.notify_one();
+
+                            let mut armed = thread_state
+                                .armed
+                                .lock()
+                                .unwrap_or_else(|error| error.into_inner());
+                            while !*armed && !thread_state.shutdown.load(Ordering::Acquire) {
+                                armed = thread_state
+                                    .condvar
+                                    .wait(armed)
+                                    .unwrap_or_else(|error| error.into_inner());
+                            }
+                            if thread_state.shutdown.load(Ordering::Acquire) {
+                                break;
+                            }
+                        }
+                        result if result == WAIT_OBJECT_0 + 1 => break,
+                        WAIT_FAILED => {
+                            log::error!(
+                                "wait wintun read event failed: {}",
+                                std::io::Error::last_os_error()
+                            );
+                            break;
+                        }
+                        other => {
+                            log::error!(
+                                "wait wintun read event returned unexpected value: {other}"
+                            );
+                            break;
+                        }
+                    }
+                }
+            }) {
+            Ok(thread) => thread,
+            Err(error) => {
+                unsafe { CloseHandle(shutdown_event) };
+                return Err(error.into());
+            }
+        };
+
+        Ok(Self {
+            wake,
+            state,
+            shutdown_event,
+            thread: Some(thread),
+        })
+    }
+
+    async fn readable(&self) -> std::io::Result<()> {
+        self.wake.notified().await;
+        Ok(())
+    }
+
+    fn arm(&self) {
+        let mut armed = self
+            .state
+            .armed
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if !*armed {
+            *armed = true;
+            self.state.condvar.notify_one();
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WintunReady {
+    fn drop(&mut self) {
+        self.state.shutdown.store(true, Ordering::Release);
+        if unsafe { SetEvent(self.shutdown_event) } == FALSE {
+            log::error!(
+                "set wintun readiness shutdown event failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        self.state.condvar.notify_one();
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+        if unsafe { CloseHandle(self.shutdown_event) } == FALSE {
+            log::error!(
+                "close wintun readiness shutdown event failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct RawTunFd(RawFd);
+
+#[cfg(target_os = "macos")]
+impl AsRawFd for RawTunFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct OsxTunReady {
+    fd: tokio::io::unix::AsyncFd<RawTunFd>,
+}
+
+#[cfg(target_os = "macos")]
+impl OsxTunReady {
+    fn new(tun: &OsxTun) -> std::io::Result<Self> {
+        Ok(Self {
+            fd: tokio::io::unix::AsyncFd::new(RawTunFd(tun.raw_fd()))?,
+        })
+    }
+
+    async fn readable(&self) -> std::io::Result<()> {
+        let mut guard = self.fd.readable().await?;
+        guard.clear_ready();
+        Ok(())
+    }
+
+    fn arm(&self) {}
+}
+
+async fn wait_stack_delay(delay: Option<Duration>) {
+    if let Some(delay) = delay {
+        tokio::time::sleep(delay).await;
+    } else {
+        std::future::pending::<()>().await;
+    }
+}
 
 pub async fn init_tls_conn(
     connector: TlsConnector,
@@ -95,9 +301,10 @@ async fn async_run() -> Result<()> {
 
     let server_addr = *OPTIONS.back_addr.as_ref().unwrap();
     let mtu = OPTIONS.wintun_args().mtu;
+    let tun_ready = PlatformTunReady::new(session.clone())?;
     let mut device = TunDevice::new(Wintun::new(mtu, session));
     device.add_black_ip(server_addr.ip());
-    run_device(device).await
+    run_device(device, tun_ready).await
 }
 
 #[cfg(target_os = "macos")]
@@ -113,6 +320,7 @@ async fn async_run() -> Result<()> {
     };
     let mtu = OPTIONS.wintun_args().mtu;
     let tun = OsxTun::create(mtu)?;
+    let tun_ready = PlatformTunReady::new(&tun)?;
     let interface = tun.interface_name().to_string();
     let route_config = RouteConfig {
         interface: interface.clone(),
@@ -132,10 +340,10 @@ async fn async_run() -> Result<()> {
     let mut device = TunDevice::new(tun);
     device.add_black_ip(server_addr.ip());
     device.allow_private(true);
-    run_device(device).await
+    run_device(device, tun_ready).await
 }
 
-async fn run_device<T>(mut device: TunDevice<'_, T>) -> Result<()>
+async fn run_device<T>(mut device: TunDevice<'_, T>, tun_ready: PlatformTunReady) -> Result<()>
 where
     T: Tun + Clone,
 {
@@ -169,10 +377,50 @@ where
         close_receiver,
         close_sender.clone(),
     ));
-    let mut last_speed_time = Instant::now();
+    let device_wake = device.notifier();
+    let mut speed_tick = interval(Duration::from_secs(1));
+    speed_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    speed_tick.tick().await;
+    let mut maintenance_tick = interval(Duration::from_secs(1));
+    maintenance_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    maintenance_tick.tick().await;
 
     loop {
+        let stack_delay = device.poll_delay();
+        let poll_stack = tokio::select! {
+            result = tun_ready.readable() => {
+                result?;
+                true
+            }
+            _ = device_wake.notified() => true,
+            _ = wait_stack_delay(stack_delay) => true,
+            _ = speed_tick.tick() => {
+                let (rx_speed, tx_speed) = device.calculate_speed();
+                log::info!(
+                    "current speed - rx:{:.4}KB/s, tx:{:.4}/KB/s",
+                    rx_speed,
+                    tx_speed
+                );
+                let mut file = OpenOptions::new()
+                    .create(true)
+                    .truncate(true)
+                    .write(true)
+                    .open(OPTIONS.wintun_args().status_file.as_str())?;
+                write!(&mut file, "{:.4} {:.4}", rx_speed, tx_speed)?;
+                false
+            }
+            _ = maintenance_tick.tick() => {
+                device.maintenance();
+                false
+            }
+        };
+
+        if !poll_stack {
+            continue;
+        }
+
         let (tcp_streams, udp_sockets) = device.poll();
+        tun_ready.arm();
         for stream in tcp_streams {
             log::info!(
                 "accept tcp {} - {}",
@@ -187,21 +435,19 @@ where
             let _ = socket_sender.send(writer).await;
             spawn(start_udp(socket, data_sender.clone(), close_sender.clone()));
         }
-        if last_speed_time.elapsed().as_millis() > 1000 {
-            let (rx_speed, tx_speed) = device.calculate_speed();
-            log::info!(
-                "current speed - rx:{:.4}KB/s, tx:{:.4}/KB/s",
-                rx_speed,
-                tx_speed
-            );
-            let mut file = OpenOptions::new()
-                .create(true)
-                .truncate(true)
-                .write(true)
-                .open(OPTIONS.wintun_args().status_file.as_str())?;
-            write!(&mut file, "{:.4} {:.4}", rx_speed, tx_speed)?;
-            last_speed_time = Instant::now();
-        }
-        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn awintun_loop_does_not_use_fixed_poll_sleep() {
+        let source = include_str!("mod.rs");
+        let fixed_poll_sleep = concat!("sleep", "(Duration::from_millis(1))");
+
+        assert!(
+            !source.contains(fixed_poll_sleep),
+            "awintun should wake from tun readiness, device notifications, or smoltcp timers instead of fixed 1ms polling"
+        );
     }
 }

--- a/src/osxtun/tun.rs
+++ b/src/osxtun/tun.rs
@@ -45,6 +45,10 @@ impl OsxTun {
     pub fn interface_name(&self) -> &str {
         &self.interface_name
     }
+
+    pub fn raw_fd(&self) -> RawFd {
+        self.fd.0
+    }
 }
 
 impl Tun for OsxTun {

--- a/trojan-client/src-tauri/src/main.rs
+++ b/trojan-client/src-tauri/src/main.rs
@@ -19,11 +19,13 @@ use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use tauri::{
     image::Image,
-    menu::{Menu, MenuItem, PredefinedMenuItem},
+    menu::{Menu, MenuItem},
     path::BaseDirectory,
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
     AppHandle, Emitter, Manager, RunEvent, State, WebviewWindow, WindowEvent, Wry,
 };
+#[cfg(debug_assertions)]
+use tauri::menu::PredefinedMenuItem;
 use tauri_plugin_log::{Target, TargetKind};
 use tauri_plugin_shell::{
     process::{CommandChild, CommandEvent},


### PR DESCRIPTION
## Summary
- replace the fixed 10ms Android atun device polling loop with event-driven polling
- wake the smoltcp driver from TUN fd readiness, egress channel writes, and smoltcp poll delays
- keep idle maintenance separate from stack polling so maps can shrink without busy polling
- reduce hot-path packet logs from info to debug

## Validation
- `cargo test --manifest-path async_smoltcp/Cargo.toml`
- `cargo check --manifest-path mobile/src-tauri/Cargo.toml`
- `cargo ndk -t arm64-v8a check --manifest-path mobile/src-tauri/Cargo.toml`
- `cargo check`
- `git diff --check`

## Notes
- local mobile screenshots/logs are not included in this PR
- draft PR while waiting for Gemini review feedback