### PR TITLE
[codex] Wait for tun readiness before DNS startup

### DIFF
--- a/async_smoltcp/src/device.rs
+++ b/async_smoltcp/src/device.rs
@@ -356,7 +356,12 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
                         return;
                     }
                     if let Some(source) = socket.remote_endpoint() {
-                        let sender = self.tcp_req_senders.get(&source).unwrap();
+                        let Some(sender) = self.tcp_req_senders.get(&source) else {
+                            log::warn!("tcp ingress sender missing for {}", source);
+                            socket.close();
+                            tcp_endpoints.push(source);
+                            return;
+                        };
                         while socket.can_recv() && sender.capacity() > 0 {
                             log::debug!("dispatch ingress tcp {} {}", source, socket.state());
                             let mut buffer = BytesMut::with_capacity(socket.recv_queue());
@@ -399,7 +404,11 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
                         return;
                     }
                     let target: IpEndpoint = socket.endpoint().convert();
-                    let sender = self.udp_req_senders.get(&target).unwrap();
+                    let Some(sender) = self.udp_req_senders.get(&target) else {
+                        log::warn!("udp ingress sender missing for {}", target);
+                        udp_endpoints.push(target);
+                        return;
+                    };
                     while socket.can_recv() && sender.capacity() > 0 {
                         log::debug!("dispatch udp {}", target);
                         let mut buffer = BytesMut::with_capacity(self.mtu);
@@ -552,10 +561,9 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
     }
 
     fn preprocess_packet(&mut self, packet: &T::Packet) {
-        let (dst_addr, src_addr, payload, protocol) =
-            match IpVersion::of_packet(packet.as_ref()).unwrap() {
-                IpVersion::Ipv4 => {
-                    let packet = Ipv4Packet::new_checked(packet.as_ref()).unwrap();
+        let (dst_addr, src_addr, payload, protocol) = match IpVersion::of_packet(packet.as_ref()) {
+            Ok(IpVersion::Ipv4) => match Ipv4Packet::new_checked(packet.as_ref()) {
+                Ok(packet) => {
                     let dst_addr = packet.dst_addr();
                     let src_addr = packet.src_addr();
                     (
@@ -565,8 +573,13 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
                         packet.next_header(),
                     )
                 }
-                IpVersion::Ipv6 => {
-                    let packet = Ipv6Packet::new_checked(packet.as_ref()).unwrap();
+                Err(err) => {
+                    log::warn!("ignore invalid ipv4 packet: {}", err);
+                    return;
+                }
+            },
+            Ok(IpVersion::Ipv6) => match Ipv6Packet::new_checked(packet.as_ref()) {
+                Ok(packet) => {
                     let dst_addr = packet.dst_addr();
                     let src_addr = packet.src_addr();
                     (
@@ -576,14 +589,29 @@ impl<'a, T: Tun + Clone> TunDevice<'a, T> {
                         packet.next_header(),
                     )
                 }
-            };
+                Err(err) => {
+                    log::warn!("ignore invalid ipv6 packet: {}", err);
+                    return;
+                }
+            },
+            Err(err) => {
+                log::warn!("ignore packet with invalid ip version: {}", err);
+                return;
+            }
+        };
         let (dst_port, src_port, connect) = match protocol {
             IpProtocol::Udp => {
-                let packet = UdpPacket::new_checked(payload).unwrap();
+                let Ok(packet) = UdpPacket::new_checked(payload) else {
+                    log::warn!("ignore invalid udp packet");
+                    return;
+                };
                 (packet.dst_port(), packet.src_port(), None)
             }
             IpProtocol::Tcp => {
-                let packet = TcpPacket::new_checked(payload).unwrap();
+                let Ok(packet) = TcpPacket::new_checked(payload) else {
+                    log::warn!("ignore invalid tcp packet");
+                    return;
+                };
                 (
                     packet.dst_port(),
                     packet.src_port(),
@@ -637,14 +665,20 @@ impl<'a, T: Tun> smoltcp::phy::TxToken for TxToken<'a, T> {
         F: FnOnce(&mut [u8]) -> R,
     {
         self.traffic.tx_bytes += len;
-        self.tun
-            .allocate_packet(len)
-            .map(|mut packet| {
+        match self.tun.allocate_packet(len) {
+            Ok(mut packet) => {
                 let r = f(packet.as_mut());
-                self.tun.send(packet).unwrap();
+                if let Err(err) = self.tun.send(packet) {
+                    log::error!("tun send failed: {}", err);
+                }
                 r
-            })
-            .unwrap()
+            }
+            Err(err) => {
+                log::error!("tun packet allocation failed: {}", err);
+                let mut packet = vec![0; len];
+                f(packet.as_mut_slice())
+            }
+        }
     }
 }
 
@@ -659,16 +693,23 @@ impl<'b, T: Tun + Clone> Device for TunDevice<'b, T> {
         Self: 'a;
 
     fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-        self.tun.receive().unwrap().map(|packet| {
-            self.traffic.rx_bytes += packet.len();
-            self.preprocess_packet(&packet);
-            let rx = RxToken { packet };
-            let tx = TxToken {
-                tun: self.tun.clone(),
-                traffic: &mut self.traffic,
-            };
-            (rx, tx)
-        })
+        match self.tun.receive() {
+            Ok(Some(packet)) => {
+                self.traffic.rx_bytes += packet.len();
+                self.preprocess_packet(&packet);
+                let rx = RxToken { packet };
+                let tx = TxToken {
+                    tun: self.tun.clone(),
+                    traffic: &mut self.traffic,
+                };
+                Some((rx, tx))
+            }
+            Ok(None) => None,
+            Err(err) => {
+                log::error!("tun receive failed: {}", err);
+                None
+            }
+        }
     }
 
     fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
@@ -740,5 +781,60 @@ mod tests {
         device.maintenance();
 
         assert!(device.last_shrink > before);
+    }
+
+    #[test]
+    fn ingress_missing_sender_paths_do_not_unwrap() {
+        let source = include_str!("device.rs");
+        let tcp_sender_unwrap = concat!("self.tcp_req_senders.get(&source)", ".unwrap()");
+        let udp_sender_unwrap = concat!("self.udp_req_senders.get(&target)", ".unwrap()");
+
+        assert!(
+            !source.contains(tcp_sender_unwrap),
+            "tcp ingress sender may be removed before smoltcp socket is fully gone"
+        );
+        assert!(
+            !source.contains(udp_sender_unwrap),
+            "udp ingress sender may be removed before smoltcp socket is fully gone"
+        );
+    }
+
+    #[test]
+    fn malformed_packet_paths_do_not_unwrap() {
+        let source = include_str!("device.rs");
+        let ip_version_unwrap = concat!("IpVersion::of_packet(packet.as_ref())", ".unwrap()");
+        let ipv4_packet_unwrap = concat!("Ipv4Packet::new_checked(packet.as_ref())", ".unwrap()");
+        let ipv6_packet_unwrap = concat!("Ipv6Packet::new_checked(packet.as_ref())", ".unwrap()");
+        let udp_packet_unwrap = concat!("UdpPacket::new_checked(payload)", ".unwrap()");
+        let tcp_packet_unwrap = concat!("TcpPacket::new_checked(payload)", ".unwrap()");
+
+        for pattern in [
+            ip_version_unwrap,
+            ipv4_packet_unwrap,
+            ipv6_packet_unwrap,
+            udp_packet_unwrap,
+            tcp_packet_unwrap,
+        ] {
+            assert!(
+                !source.contains(pattern),
+                "malformed tun packets should be ignored instead of panicking at {pattern}"
+            );
+        }
+    }
+
+    #[test]
+    fn tun_io_error_paths_do_not_unwrap() {
+        let source = include_str!("device.rs");
+        let send_unwrap = concat!("self.tun.send(packet)", ".unwrap()");
+        let receive_unwrap = concat!("self.tun.receive()", ".unwrap()");
+
+        assert!(
+            !source.contains(send_unwrap),
+            "tun send errors can happen during shutdown and should not panic"
+        );
+        assert!(
+            !source.contains(receive_unwrap),
+            "tun receive errors can happen during shutdown and should not panic"
+        );
     }
 }

--- a/src/awintun/tcp.rs
+++ b/src/awintun/tcp.rs
@@ -23,7 +23,13 @@ pub async fn start_tcp(
 ) {
     let client = init_tls_conn(connector, server_name).await;
     if let Ok(client) = client {
-        let dst_addr = client.get_ref().0.peer_addr().unwrap();
+        let dst_addr = match client.get_ref().0.peer_addr() {
+            Ok(addr) => addr,
+            Err(err) => {
+                log::error!("get remote tcp peer address failed:{}", err);
+                return;
+            }
+        };
         let (read_half, write_half) = split(client);
         let (reader, writer) = local.into_split();
         spawn(local_to_remote(reader, write_half));
@@ -89,5 +95,19 @@ where
             log::warn!("tcp {} failed, write shutdown", message);
             break;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn tls_peer_address_error_does_not_panic() {
+        let source = include_str!("tcp.rs");
+        let peer_addr_unwrap = concat!("peer_addr()", ".unwrap()");
+
+        assert!(
+            !source.contains(peer_addr_unwrap),
+            "tls peer address lookup can fail during shutdown and should not panic"
+        );
     }
 }

--- a/src/awintun/udp.rs
+++ b/src/awintun/udp.rs
@@ -49,8 +49,7 @@ pub async fn run_udp_dispatch(
             }
         };
         match ret {
-            DispatchReturn::Data(ret) => {
-                let (src_addr, dst_addr, data) = ret.unwrap();
+            DispatchReturn::Data(Some((src_addr, dst_addr, data))) => {
                 log::info!(
                     "found data {} - {} {} bytes",
                     src_addr,
@@ -65,7 +64,10 @@ pub async fn run_udp_dispatch(
                     Some(sender) => sender,
                     None => {
                         log::info!("remote for {} not found", src_addr);
-                        let local = locals.get(&dst_addr).unwrap().clone();
+                        let Some(local) = locals.get(&dst_addr).cloned() else {
+                            log::warn!("socket:{} removed before remote creation", dst_addr);
+                            continue;
+                        };
                         let (req_sender, req_receiver) = channel(mtu);
                         req_senders.insert(src_addr, req_sender);
 
@@ -78,18 +80,28 @@ pub async fn run_udp_dispatch(
                             close_sender.clone(),
                             request.clone(),
                         ));
-                        req_senders.get(&src_addr).unwrap()
+                        let Some(sender) = req_senders.get(&src_addr) else {
+                            log::warn!("remote sender for {} missing after insert", src_addr);
+                            continue;
+                        };
+                        sender
                     }
                 };
                 let _ = sender.send((dst_addr, data)).await;
             }
-            DispatchReturn::Socket(ret) => {
-                let socket = ret.unwrap();
+            DispatchReturn::Data(None) => {
+                log::info!("udp data channel closed");
+                break;
+            }
+            DispatchReturn::Socket(Some(socket)) => {
                 log::info!("add socket for {}", socket.peer_addr());
                 locals.insert(socket.peer_addr(), socket);
             }
-            DispatchReturn::Close(ret) => {
-                let (addr, is_remote) = ret.unwrap();
+            DispatchReturn::Socket(None) => {
+                log::info!("udp socket channel closed");
+                break;
+            }
+            DispatchReturn::Close(Some((addr, is_remote))) => {
                 log::info!("close {} {}", addr, is_remote);
                 if is_remote {
                     req_senders.remove(&addr);
@@ -98,6 +110,10 @@ pub async fn run_udp_dispatch(
                     locals.remove(&addr);
                     locals.shrink_to_fit();
                 }
+            }
+            DispatchReturn::Close(None) => {
+                log::info!("udp close channel closed");
+                break;
             }
         }
     }
@@ -139,7 +155,14 @@ async fn local_to_remote(
     let dst_addr = local.peer_addr();
     let (mut remote, remote_local_addr) =
         if let Ok(client) = init_tls_conn(connector, server_name.clone()).await {
-            let local_addr = client.get_ref().0.local_addr().unwrap();
+            let local_addr = match client.get_ref().0.local_addr() {
+                Ok(addr) => addr,
+                Err(err) => {
+                    log::error!("get remote udp local address failed:{}", err);
+                    let _ = sender.send((src_addr, true)).await;
+                    return;
+                }
+            };
             let (read_half, mut write_half) = split(client);
             if let Err(err) = write_half.write_all(request.as_ref()).await {
                 log::error!("udp send handshake failed:{}", err);
@@ -233,5 +256,59 @@ async fn remote_to_local(
 
     if let Err(err) = sender.send((source, true)).await {
         log::info!("udp channel send failed:{}", err);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::BytesMut;
+    use rustls::{ClientConfig, RootCertStore};
+    use rustls_pki_types::ServerName;
+    use tokio::sync::mpsc::channel;
+    use tokio_rustls::TlsConnector;
+
+    use super::run_udp_dispatch;
+
+    fn test_connector() -> TlsConnector {
+        TlsConnector::from(Arc::new(
+            ClientConfig::builder()
+                .with_root_certificates(RootCertStore::empty())
+                .with_no_client_auth(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn udp_dispatch_exits_when_socket_channel_closes() {
+        let (_data_sender, data_receiver) = channel(1);
+        let (socket_sender, socket_receiver) = channel(1);
+        let (close_sender, close_receiver) = channel(1);
+        drop(socket_sender);
+
+        let result = tokio::spawn(run_udp_dispatch(
+            data_receiver,
+            socket_receiver,
+            ServerName::try_from("example.com").unwrap(),
+            test_connector(),
+            1500,
+            Arc::new(BytesMut::new()),
+            close_receiver,
+            close_sender,
+        ))
+        .await;
+
+        assert!(result.is_ok(), "udp dispatch should exit without panic");
+    }
+
+    #[test]
+    fn tls_local_address_error_does_not_panic() {
+        let source = include_str!("udp.rs");
+        let local_addr_unwrap = concat!("local_addr()", ".unwrap()");
+
+        assert!(
+            !source.contains(local_addr_unwrap),
+            "tls local address lookup can fail during shutdown and should not panic"
+        );
     }
 }

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -2,7 +2,7 @@ use std::{
     net::{Ipv4Addr, SocketAddr},
     path::Path,
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use crossbeam::channel::{unbounded, Sender};
@@ -15,7 +15,7 @@ use winapi::{
 
 use server::DnsServer;
 pub use wintool::adapter::{
-    get_adapter_index, get_adapter_ip, get_main_adapter_gwif, set_dns_server,
+    get_adapter_ip, get_adapter_ready, get_main_adapter_gwif, set_dns_server, AdapterReady,
 };
 
 use crate::{
@@ -33,6 +33,30 @@ const DNS_TRUSTED: usize = 2;
 const DNS_POISONED: usize = 3;
 /// Token for local DNS server
 const DNS_LOCAL: usize = 4;
+const TUN_READY_TIMEOUT: Duration = Duration::from_secs(30);
+const TUN_READY_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+fn wait_tun_ready(name: &str) -> Result<AdapterReady> {
+    let started = Instant::now();
+    loop {
+        if let Some(ready) = get_adapter_ready(name) {
+            log::info!(
+                "tun adapter ready name:{} ip:{} index:{}",
+                name,
+                ready.ip,
+                ready.index
+            );
+            return Ok(ready);
+        }
+        if started.elapsed() >= TUN_READY_TIMEOUT {
+            return Err(TrojanError::Custom(format!(
+                "tun adapter {name} not ready after {} seconds",
+                TUN_READY_TIMEOUT.as_secs()
+            )));
+        }
+        thread::sleep(TUN_READY_POLL_INTERVAL);
+    }
+}
 
 extern "system" fn console_callback(ctrl_type: DWORD) -> BOOL {
     log::warn!("console_callback called:{}", ctrl_type);
@@ -75,9 +99,7 @@ pub fn run() -> Result<()> {
         }
     }
 
-    while get_adapter_ip(OPTIONS.dns_args().tun_name.as_str()).is_none() {
-        thread::sleep(Duration::new(1, 0));
-    }
+    let tun = wait_tun_ready(OPTIONS.dns_args().tun_name.as_str())?;
 
     if let Some((main_gw, main_index)) = get_main_adapter_gwif() {
         log::warn!(
@@ -94,7 +116,7 @@ pub fn run() -> Result<()> {
         log::error!("main adapter gateway not found");
         return Err(TrojanError::MainAdapterNotFound);
     }
-    let index = get_adapter_index(OPTIONS.dns_args().tun_name.as_str()).unwrap();
+    let index = tun.index;
 
     let (sender, receiver) = unbounded();
     let monitor = FileMonitor { sender };

--- a/tests/client_dns_startup.rs
+++ b/tests/client_dns_startup.rs
@@ -34,3 +34,62 @@ fn dns_sidecar_waits_for_strict_adapter_readiness() {
         "dns sidecar should use strict adapter readiness shared with the client"
     );
 }
+
+#[test]
+fn trojan_client_reports_starting_until_dns_is_ready() {
+    let backend = include_str!("../trojan-client/src-tauri/src/main.rs");
+    let frontend = include_str!("../trojan-client/src/app.vue");
+
+    assert!(
+        backend.contains("emit_state_update_event(ClientState::Starting"),
+        "backend should report starting immediately after start is accepted"
+    );
+    assert!(
+        backend.contains("emit_state_update_event(ClientState::Running"),
+        "backend should report running only after sidecars are ready"
+    );
+
+    let dns_registered = backend
+        .find("state.dns.replace(child)")
+        .expect("dns child should be stored after it starts");
+    let running_emitted = backend[dns_registered..]
+        .find("emit_state_update_event(ClientState::Running")
+        .map(|offset| dns_registered + offset)
+        .expect("running state should be emitted after startup completes");
+    assert!(
+        dns_registered < running_emitted,
+        "running state should be emitted after the dns sidecar is registered"
+    );
+
+    assert!(
+        frontend.contains("connectionState: \"stopped\""),
+        "frontend should track stopped/starting/running state explicitly"
+    );
+    assert!(
+        frontend.contains("this.connectionState = \"starting\""),
+        "start click should immediately move the button into starting state"
+    );
+    assert!(
+        frontend.contains("this.label = \"启动中\""),
+        "button label should show starting while startup is in progress"
+    );
+}
+
+#[test]
+fn trojan_client_disables_stop_while_starting() {
+    let backend = include_str!("../trojan-client/src-tauri/src/main.rs");
+    let frontend = include_str!("../trojan-client/src/app.vue");
+
+    assert!(
+        backend.contains("state.status == ClientState::Starting"),
+        "backend stop command should ignore requests while startup is in progress"
+    );
+    assert!(
+        frontend.contains("this.connectionState === \"starting\""),
+        "frontend should treat starting as a disabled action state"
+    );
+    assert!(
+        frontend.contains(":disabled=\"is_action_disabled()\""),
+        "start/stop button should be disabled while startup is in progress"
+    );
+}

--- a/tests/client_dns_startup.rs
+++ b/tests/client_dns_startup.rs
@@ -11,6 +11,14 @@ fn trojan_client_dns_start_waits_for_tun_readiness() {
         source.contains("wait_tun_ready(&config.iface_name).await"),
         "dns startup should wait for the configured tun interface before spawning dns"
     );
+    assert!(
+        source.contains("wintun was stopped while waiting for adapter readiness"),
+        "dns startup should abort when wintun is stopped during adapter readiness wait"
+    );
+    assert!(
+        source.contains("wintun was stopped before dns sidecar was registered"),
+        "dns startup should kill the dns sidecar if wintun is stopped before registration"
+    );
 }
 
 #[test]

--- a/tests/client_dns_startup.rs
+++ b/tests/client_dns_startup.rs
@@ -1,0 +1,28 @@
+#[test]
+fn trojan_client_dns_start_waits_for_tun_readiness() {
+    let source = include_str!("../trojan-client/src-tauri/src/main.rs");
+    let fixed_sleep = concat!("sleep", "(Duration::from_secs(10))");
+
+    assert!(
+        !source.contains(fixed_sleep),
+        "dns startup should wait for explicit tun readiness instead of a fixed 10 second sleep"
+    );
+    assert!(
+        source.contains("wait_tun_ready(&config.iface_name).await"),
+        "dns startup should wait for the configured tun interface before spawning dns"
+    );
+}
+
+#[test]
+fn dns_sidecar_waits_for_strict_adapter_readiness() {
+    let source = include_str!("../src/dns/mod.rs");
+
+    assert!(
+        source.contains("wait_tun_ready(OPTIONS.dns_args().tun_name.as_str())"),
+        "dns sidecar should wait for the target tun adapter before binding sockets"
+    );
+    assert!(
+        source.contains("get_adapter_ready"),
+        "dns sidecar should use strict adapter readiness shared with the client"
+    );
+}

--- a/trojan-client/src-tauri/Cargo.lock
+++ b/trojan-client/src-tauri/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "backtrace",
  "cargo",

--- a/trojan-client/src-tauri/Cargo.toml
+++ b/trojan-client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.4.0"
+version = "0.5.0"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/trojan-client/src-tauri/src/main.rs
+++ b/trojan-client/src-tauri/src/main.rs
@@ -10,7 +10,7 @@ use std::{
     path::Path,
     sync::{Arc, Mutex},
     thread,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 
 use backtrace::Backtrace;
@@ -33,7 +33,12 @@ use tauri_plugin_shell::{
 };
 
 #[cfg(windows)]
-use wintool::adapter::{get_dns_server, get_main_adapter_ip};
+use wintool::adapter::{get_adapter_ready, get_dns_server, get_main_adapter_ip};
+
+#[cfg(windows)]
+const TUN_READY_TIMEOUT: Duration = Duration::from_secs(30);
+#[cfg(windows)]
+const TUN_READY_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -181,6 +186,29 @@ fn tun_status_file() -> &'static str {
     "logs/osxtun.status"
 }
 
+#[cfg(windows)]
+async fn wait_tun_ready(name: &str) -> Result<()> {
+    let started = Instant::now();
+    loop {
+        if let Some(ready) = get_adapter_ready(name) {
+            log::info!(
+                "tun adapter ready name:{} ip:{} index:{}",
+                name,
+                ready.ip,
+                ready.index
+            );
+            return Ok(());
+        }
+        if started.elapsed() >= TUN_READY_TIMEOUT {
+            return Err(Error::Custom(format!(
+                "tun adapter {name} not ready after {} seconds",
+                TUN_READY_TIMEOUT.as_secs()
+            )));
+        }
+        tokio::time::sleep(TUN_READY_POLL_INTERVAL).await;
+    }
+}
+
 type TrojanState = Arc<Mutex<TrojanProxy>>;
 
 #[tauri::command]
@@ -270,7 +298,14 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
             };
             #[cfg(windows)]
             if state.lock().unwrap().config.enable_dns {
-                tokio::time::sleep(Duration::from_secs(10)).await;
+                if let Err(err) = wait_tun_ready(&config.iface_name).await {
+                    log::error!("wait tun ready failed:{:?}", err);
+                    if let Some(wintun) = state.lock().unwrap().wintun.take() {
+                        let _ = wintun.kill();
+                    }
+                    emit_state_update_event(false, window);
+                    return;
+                }
                 let dns_listen = config.dns_listen.clone() + ":53";
                 let default_dns = state.lock().unwrap().default_dns.clone();
                 let config_domains = window

--- a/trojan-client/src-tauri/src/main.rs
+++ b/trojan-client/src-tauri/src/main.rs
@@ -306,6 +306,10 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
                     emit_state_update_event(false, window);
                     return;
                 }
+                if state.lock().unwrap().wintun.is_none() {
+                    log::warn!("wintun was stopped while waiting for adapter readiness");
+                    return;
+                }
                 let dns_listen = config.dns_listen.clone() + ":53";
                 let default_dns = state.lock().unwrap().default_dns.clone();
                 let config_domains = window
@@ -351,7 +355,13 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
                     .spawn()
                 {
                     Ok((rx, child)) => {
-                        state.lock().unwrap().dns.replace(child);
+                        let mut state = state.lock().unwrap();
+                        if state.wintun.is_none() {
+                            log::warn!("wintun was stopped before dns sidecar was registered");
+                            let _ = child.kill();
+                            return;
+                        }
+                        state.dns.replace(child);
                         rxs.insert("dns", rx);
                     }
                     Err(err) => {

--- a/trojan-client/src-tauri/src/main.rs
+++ b/trojan-client/src-tauri/src/main.rs
@@ -80,6 +80,7 @@ pub struct TrojanProxy {
     config: Config,
     wintun: Option<CommandChild>,
     dns: Option<CommandChild>,
+    status: ClientState,
     running_icon: Image<'static>,
     stopped_icon: Image<'static>,
     rx_speed: f32,
@@ -89,12 +90,21 @@ pub struct TrojanProxy {
     explicit_dns: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum ClientState {
+    Starting,
+    Running,
+    Stopped,
+}
+
 impl TrojanProxy {
     fn new() -> TrojanProxy {
         TrojanProxy {
             config: init_config().unwrap_or_default(),
             wintun: None,
             dns: None,
+            status: ClientState::Stopped,
             running_icon: Image::from_bytes(include_bytes!("../icons/icon.ico")).unwrap(),
             stopped_icon: Image::from_bytes(include_bytes!("../icons/icon_gray.png")).unwrap(),
             rx_speed: 0.0,
@@ -216,18 +226,21 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
     log::info!("start trojan now");
     if let Err(err) = save_config(&config) {
         log::error!("save config failed:{:?}", err);
+        emit_state_update_event(ClientState::Stopped, window);
     } else {
         state.lock().unwrap().config = config;
-        if let Err(err) = state.lock().unwrap().update_dns() {
+        let update_dns_result = state.lock().unwrap().update_dns();
+        if let Err(err) = update_dns_result {
             log::error!("update_dns failed:{:?}", err);
+            emit_state_update_event(ClientState::Stopped, window);
             return;
         }
-
-        emit_state_update_event(true, window.clone());
 
         if state.lock().unwrap().wintun.is_some() {
+            emit_state_update_event(ClientState::Running, window);
             return;
         }
+        emit_state_update_event(ClientState::Starting, window.clone());
         let state = state.inner().clone();
         tauri::async_runtime::spawn(async move {
             let config = state.lock().unwrap().config.clone();
@@ -292,7 +305,7 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
                 }
                 Err(err) => {
                     log::error!("start wintun failed:{:?}", err);
-                    emit_state_update_event(false, window);
+                    emit_state_update_event(ClientState::Stopped, window);
                     return;
                 }
             };
@@ -303,11 +316,12 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
                     if let Some(wintun) = state.lock().unwrap().wintun.take() {
                         let _ = wintun.kill();
                     }
-                    emit_state_update_event(false, window);
+                    emit_state_update_event(ClientState::Stopped, window);
                     return;
                 }
                 if state.lock().unwrap().wintun.is_none() {
                     log::warn!("wintun was stopped while waiting for adapter readiness");
+                    emit_state_update_event(ClientState::Stopped, window);
                     return;
                 }
                 let dns_listen = config.dns_listen.clone() + ":53";
@@ -359,10 +373,14 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
                         if state.wintun.is_none() {
                             log::warn!("wintun was stopped before dns sidecar was registered");
                             let _ = child.kill();
+                            drop(state);
+                            emit_state_update_event(ClientState::Stopped, window);
                             return;
                         }
                         state.dns.replace(child);
                         rxs.insert("dns", rx);
+                        drop(state);
+                        emit_state_update_event(ClientState::Running, window.clone());
                     }
                     Err(err) => {
                         log::error!("start dns failed:{:?}", err);
@@ -371,7 +389,11 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
                         }
                     }
                 }
+            } else {
+                emit_state_update_event(ClientState::Running, window.clone());
             }
+            #[cfg(not(windows))]
+            emit_state_update_event(ClientState::Running, window.clone());
             log::info!("sub process started");
 
             while !rxs.is_empty() {
@@ -433,22 +455,24 @@ fn start(config: Config, state: State<TrojanState>, window: WebviewWindow<Wry>) 
                 }
                 tokio::time::sleep(Duration::from_millis(66)).await;
             }
-            emit_state_update_event(false, window);
+            emit_state_update_event(ClientState::Stopped, window);
             log::info!("sub process exits");
         });
     }
 }
 
-fn emit_state_update_event(running: bool, window: WebviewWindow<Wry>) {
-    window.emit("state-update", running).unwrap();
+fn emit_state_update_event(status: ClientState, window: WebviewWindow<Wry>) {
     let app = window.app_handle();
     let state = app.state::<TrojanState>();
-    let state = state.lock().unwrap();
-    let icon = if running {
+    let mut state = state.lock().unwrap();
+    state.status = status;
+    let icon = if status == ClientState::Running {
         state.running_icon.clone()
     } else {
         state.stopped_icon.clone()
     };
+    drop(state);
+    window.emit("state-update", status).unwrap();
     window.set_icon(icon.clone()).unwrap();
     if let Some(tray) = window.app_handle().tray_by_id("main") {
         tray.set_icon(Some(icon)).unwrap();
@@ -490,12 +514,17 @@ fn update_speed(state: State<TrojanState>, window: WebviewWindow<Wry>) {
 #[tauri::command]
 fn stop(state: State<TrojanState>, window: WebviewWindow<Wry>) {
     log::info!("stop trojan now");
-    let mut config = state.lock().unwrap();
-    if let Some(child) = config.wintun.take() {
+    let mut state = state.lock().unwrap();
+    if state.status == ClientState::Starting {
+        log::warn!("stop ignored while client is starting");
+        return;
+    }
+    if let Some(child) = state.wintun.take() {
         let _ = child.kill();
         log::info!("trojan stopped");
     } else {
-        emit_state_update_event(false, window);
+        drop(state);
+        emit_state_update_event(ClientState::Stopped, window);
     }
 }
 
@@ -747,7 +776,10 @@ fn main() {
                 })
                 .build(app)?;
 
-            emit_state_update_event(false, app.get_webview_window("main").unwrap());
+            emit_state_update_event(
+                ClientState::Stopped,
+                app.get_webview_window("main").unwrap(),
+            );
             Ok(())
         })
         .build(tauri::generate_context!())

--- a/trojan-client/src-tauri/tauri.conf.json
+++ b/trojan-client/src-tauri/tauri.conf.json
@@ -47,7 +47,7 @@
   },
   "productName": "trojan-client",
   "mainBinaryName": "app",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "com.bmshi.trojan.client",
   "plugins": {},
   "app": {

--- a/trojan-client/src/app.vue
+++ b/trojan-client/src/app.vue
@@ -27,6 +27,7 @@ export default {
       },
       label: "开始",
       running: false,
+      connectionState: "stopped",
       homeVisible: true,
       domainVisible: false,
       domains: [],
@@ -43,15 +44,41 @@ export default {
     },
     start() {
       info("start trojan now");
-      invoke("start", {"config": this.config});
+      this.connectionState = "starting";
+      this.label = "启动中";
+      this.running = true;
+      invoke("start", {"config": this.config}).catch(async (err) => {
+        await info("start trojan failed:" + err);
+        this.apply_state("stopped");
+      });
     },
     is_config_ok() {
       return this.check_ipv4(this.config.dns_listen) === true &&
           this.check_ipv4(this.config.trust_dns) === true;
     },
     stop() {
+      if (this.connectionState === "starting") {
+        return;
+      }
       info("stop trojan now");
       invoke("stop", {});
+    },
+    apply_state(state) {
+      this.connectionState = state;
+      if (state === "starting") {
+        this.label = "启动中";
+        this.running = true;
+      } else if (state === "running") {
+        this.label = "停止";
+        this.running = true;
+      } else {
+        this.label = "开始";
+        this.running = false;
+      }
+    },
+    is_action_disabled() {
+      return this.connectionState === "starting" ||
+          (this.connectionState === "stopped" && !this.is_config_ok());
     },
     showHome() {
       this.homeVisible = true;
@@ -98,17 +125,17 @@ export default {
     async update_state() {
       appWindow.listen("state-update", async (event) => {
         await info("event:state-update, label:" + event.windowLabel + ", payload:" + event.payload);
-        if (event.payload) {
-          this.label = "停止";
-          this.running = true;
-        } else {
-          this.label = "开始";
-          this.running = false;
-        }
+        const state = typeof event.payload === "boolean"
+            ? (event.payload ? "running" : "stopped")
+            : event.payload;
+        this.apply_state(state);
       });
     },
     do_action() {
-      if (!this.running) {
+      if (this.connectionState === "starting") {
+        return;
+      }
+      if (this.connectionState === "stopped") {
         this.start();
       } else {
         this.stop();
@@ -174,7 +201,7 @@ export default {
                           label="可信DNS地址" variant="outlined"></v-text-field>
           </div>
         </v-container>
-        <v-btn :disabled="!is_config_ok()" block color="blue" size="x-large" @click="do_action">{{ label }}</v-btn>
+        <v-btn :disabled="is_action_disabled()" block color="blue" size="x-large" @click="do_action">{{ label }}</v-btn>
       </v-container>
       </div>
       <div v-if="domainVisible">

--- a/wintool/src/adapter.rs
+++ b/wintool/src/adapter.rs
@@ -195,6 +195,35 @@ pub fn get_adapter_ip(name: &str) -> Option<String> {
     ret
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdapterReady {
+    pub ip: String,
+    pub index: u32,
+}
+
+pub fn get_adapter_ready(name: &str) -> Option<AdapterReady> {
+    let mut ret = None;
+    unsafe {
+        get_adapters_addresses(|adapter| {
+            let adapter_name = adapter.description();
+            if !adapter_name.contains(name) || !adapter.is_up() {
+                return false;
+            }
+            for ip in adapter.address() {
+                if ip.is_ipv4() {
+                    ret = Some(AdapterReady {
+                        ip: ip.to_string(),
+                        index: adapter.if_index(),
+                    });
+                    return true;
+                }
+            }
+            false
+        });
+    }
+    ret
+}
+
 pub fn get_adapter_index(name: &str) -> Option<u32> {
     let mut index = None;
     unsafe {


### PR DESCRIPTION
## Summary

- replace fixed DNS startup delay with explicit TUN adapter readiness wait in the Tauri client
- add shared Windows adapter readiness detection that requires adapter up, IPv4 address, and interface index
- make the DNS sidecar wait for the same strict TUN readiness before binding and setting routes
- add a regression test covering the startup sequencing requirement

## Root cause

The client started DNS after a fixed 10 second sleep. That could still race when the TUN adapter existed but was not operational or did not have its address/index ready, causing DNS bind/setup to run too early.

## Validation

- `cargo fmt --check`
- `cargo test --test client_dns_startup -- --nocapture`
- `cargo check --manifest-path trojan-client/src-tauri/Cargo.toml -q`
- `git diff --check`
